### PR TITLE
Suggest coding styles for the meeting agenda of Mar/2019

### DIFF
--- a/docs/vc-march-2019-agenda.md
+++ b/docs/vc-march-2019-agenda.md
@@ -90,6 +90,8 @@
   - Do we need to choose coding styles?
       * Python Docstring Conventions - would be nice to have one that works with most tools (i.e. sphinx, vim syntax hightlight, IDE, napoleon, etc)
       * A `CONTRIBUTING.md` with guidelines for people creating PR for the first time (the 2 approvers rule is nice, but not well known until you send a contribution), also explaining that test coverage is desired when possible, as well as documentation update, etc
+      * Maybe worth filling in the full set of community profile e.g. https://github.com/cylc/cylc-admin/community as well.
+      * Should we use something like [Black](https://github.com/ambv/black)?
   - anything else?
 
 1. **END**

--- a/docs/vc-march-2019-agenda.md
+++ b/docs/vc-march-2019-agenda.md
@@ -87,6 +87,9 @@
 
 1. **Other?**
   - Do the other new `cylc/*` repositories need milestones?
+  - Do we need to choose coding styles?
+      * Python Docstring Conventions - would be nice to have one that works with most tools (i.e. sphinx, vim syntax hightlight, IDE, napoleon, etc)
+      * A `CONTRIBUTING.md` with guidelines for people creating PR for the first time (the 2 approvers rule is nice, but not well known until you send a contribution), also explaining that test coverage is desired when possible, as well as documentation update, etc
   - anything else?
 
 1. **END**


### PR DESCRIPTION
Quick pull request with a suggestion for coding conventions for our repositories. Our Python code is being rewritten in some packages, so this is a good time to establish code conventions to be followed.

These conventions could also be re-used in the Cylc UI Server and other Python projects.

There are already a few docstrings, but some in the google format, some in the old PEP 257, some in the docstring supported by PyCharm (_cough, cough_, sorry).

I think ideally we need one that can be used for documentation, but also by syntax highlighters and IDE's - the more tools supported, the merrier IMO.

Cheers
Bruno