### PR TITLE
Task state, trigger, and output name rationalization proposal

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,12 +19,14 @@
 - [Cylc-8 Implementation Task List](cylc-8-tasks)
 - [Cylc-8 (Proposal) Authentication between the CLI & Workflow Service](proposal-cli-wfs-authentication)
 
-## Orthogonal Work in Progress
+## Change Proposals
 - [rose suite-run migration proposal](proposal-rose-suite-run.md)
   More detail on rose-suite-run migration:
   - [Specification for new combined config file](rose-suite-run-proposal/cylc-flow-rc.md)
   - Specification for new CLI - [WIP]
 
+- [task state, output, and trigger name rationalization](proposal-state-names.md)
+ 
 ## Video Conferences
 
 Agendas and post-meeting notes.

--- a/docs/proposal-state-names.md
+++ b/docs/proposal-state-names.md
@@ -8,21 +8,21 @@ Cylc has gradually accrued new task states and associated triggers and outputs
 over the years, and the resulting names are variously ambiguous, confusing, or
 grammatically inconsistent.
 
-### Task (T) and Job (J) States
+### Task and Job States
 
-| old             | new :question:    | meaning | comment |
-|----             |----               | ---     | ---     | 
-| T   waiting         | -                 | waiting for prerequisites to be met |
-| T   queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
-| T   ready           | submitting        | queued to the subprocess pool for job submission | | 
-| T   expired         | -                 | waiting for too long, will never be submitted | | 
-| T/J submitted       | -                 | job submitted to batch system for execution | | 
-| T/J submit-failed   | submission-failed | job submission failed, did not execute | | 
-| T/J submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted |
-| T/J running         | executing         | job execution commenced | | 
-| T/J succeeded       | execution-succeeded | job execution completed successfully | | 
-| T/J failed          | execution-failed  | job execution completed, but failed | | 
-| T   retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing | 
+| Job?  | old name          | new name :question:    | meaning | comment |
+|--   | --             |----               | ---     | ---     | 
+|     | waiting         | -                 | waiting for prerequisites to be met |
+|     | queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
+|     | ready           | submitting        | queued to the subprocess pool for job submission | | 
+|     | expired         | -                 | waiting for too long, will never be submitted | | 
+| :heavy_check_mark:  | submitted       | -                 | job submitted to batch system for execution | | 
+| :heavy_check_mark:  | submit-failed   | submission-failed | job submission failed, did not execute | | 
+|     | submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted |
+| :heavy_check_mark:  | running         | executing         | job execution commenced | | 
+| :heavy_check_mark:  | succeeded       | execution-succeeded | job execution completed successfully | | 
+| :heavy_check_mark:  | failed          | execution-failed  | job execution completed, but failed | | 
+|     | retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing | 
 
 Note:
 - ("held" removed - demoted from state to attribute in Cylc 8)

--- a/docs/proposal-state-names.md
+++ b/docs/proposal-state-names.md
@@ -1,64 +1,150 @@
-# Proposal
+# Proposal (Sept-Oct 2019)
 
 ## Rationalise Task State, Output, and Trigger Names
 
-REF: https://github.com/cylc/cylc-ui/pulls#issuecomment-521121132
+Cylc has gradually accrued new task states (and associated triggers and outputs
+over the years) and they need tidying up. By thinking this through again from
+the top we can actually halve the number of abstract task states from 8 to 4.
 
-Cylc has gradually accrued new task states and associated triggers and outputs
-over the years, and the resulting names are variously ambiguous, confusing, or
-grammatically inconsistent.
+### Task/Job States
 
-### Task and Job States
+(i.e. task states that have a corresponding job state)
 
-| Job?  | old name      | new name :question: | meaning | comment |
-|--     | --              |----               | ---     | ---     | 
-|       | runahead        |  -                | in the runahead pool (too far ahead) | |
-|       | waiting         | -                 | waiting for prerequisites to be met |
-|       | queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
-|       | ready           | submitting        | queued to the subprocess pool for job submission | | 
-|       | expired         | -                 | waiting for too long, will never be submitted | | 
-| :heavy_check_mark:  | submitted       | -                 | job submitted to batch system for execution | | 
-| :heavy_check_mark:  | submit-failed   | submission-failed | job submission failed, did not execute | | 
-|     | submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted (TODO: REMOVE) |
-| :heavy_check_mark:  | running         | executing         | job execution commenced | | 
-| :heavy_check_mark:  | succeeded       | execution-succeeded | job execution completed successfully | | 
-| :heavy_check_mark:  | failed          | execution-failed  | job execution completed, but failed | | 
-|     | retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing (TODO: REMOVE) | 
+| current name      | NEW name            | meaning                       |
+| --                |----                 | ---                           |
+| `submitted`       | `submit-succeeded`  | job submitted to batch system |
+| `submit-failed`   | `submit-failed`     | job submitted but did not execute |
+| `running`         | `running`           | job started, but did not finish yet |
+| `succeeded`       | `run-succeeded`     | job finished successfully    |
+| `failed`          | `run-failed`        | job finished unsuccesfully   |
 
-Note:
-- ("held" no longer a task state - demoted from state to attribute in Cylc 8)
-- "runahead" is really implementation that should not be exposed, and will not
-  exist in the spawn-on-demand era, but so long as we still have a task pool
-  users occasionally need to understand it (e.g. if they `cylc insert` a task
-  beyond "max active cycle points").
-- The "retry" states are to be removed as for "held"
+Notes:
+- Prefixes `run-` and `submit-` added to disambiguate and make consistent
+- More verbose, but:
+  - that does not matter for documentation or display in the GUI
+  - for CLI commands that target tasks by state, we will allow the
+    old/abbreviated names for back-compat anyway
+
+### Abstract Task States
+
+(i.e. task states with no corresponding job state)
+
+#### Current Abstract Task States
+
+These are problematic in several ways, detailed below the table.  
+
+| current name       | meaning                                                   |
+|--                  |---                                                        |
+| `runahead`         | task held back because it is too far ahead                |
+| `waiting`          | waiting for prerequisites to be met                       |
+| `held`             | will not submit job even if prerequisites met                   |
+| `queued`           | held back in an internal queue                            |
+| `ready`            | preparing job submission, including subprocess pool queue |
+| `expired`          | waited too long, do not bother to submit                  |
+| `submit-retrying`  | job submission failed, will try again later               |
+| `retrying`         | job execution failed, will try again later                | 
+
+Problems:
+- `queued` (internal queue) gets confused with `submitted` (to a batch queue)
+- `ready` is not descriptive of what is actually going on (see "meaning" in the
+  table)
+- `held` is problematic as a state, e.g. what state to release to after forced
+  state manipulation during the hold?
+- `retrying` is ambiguous (should be `run-retry`) but in fact both retrying
+  states are problematic: a run-retry necessarily involves a submit-retry; the
+  word `retrying` wrongly suggests already running again. In fact "retrying"
+  is the *reason* why a previously-failed or previously submit-failed task has
+  been returned to the `waiting` state, with a new clock-trigger
+- `runahead` is really implementation that should not be exposed to users, and
+  will not exist in the spawn-on-demand era, but so long as we still have a
+  task pool users occasionally need to know about it (e.g. if they `cylc
+  insert` a task beyond *max active cycle points*).
+
+#### New Abstract Task States
+
+(These make perfect sense, and are easy to explain and understand!)
+
+| NEW name      | meaning                                             |
+|----           | ---                                                 |
+| `waiting`     | (formerly `waiting` and `queued`) waiting on **all** prequisites |
+| `preparing`   | (formerly `ready`) all prerequisites met; preparing for job submission |
+| `runahead`    | (unchanged) task held back because it is too far ahead  |
+| `expired`     | (unchanged) waited too long, do not bother to submit    |
+
+Notes:
+- `runahead` is still needed, until we get rid of the task pool (see above)
+- `queued` has been absorbed into `waiting` (internal queues are really just
+  another prerequisite to be waited on)
+- `waiting` now means waiting on all prerequisites: task dependencies, clock
+  and xtriggers, internal queues, etc.
+- removed the `held` state
+  - "held" is now just an attribute of a task, whatever its state
+  - it only affects `waiting` tasks, but we should still attach a "held" badge
+    to a task in any state to indicate that it will not submit its job even
+    if it achieves or is put in the `waiting` state
+- removed `submit-retry` and `(run-)retry` (see above)
+  - the fact that a task is going to retry will now be obvious from a) the task
+    state; and b) the job icon of the previous try
+- `preparing` includes:
+  - Writing and verifying the job file.
+  - Selecting a remote job host.
+  - Initialising the remote job host.
+  - (Waiting for user to upload the job file in a trigger-edit?)
 
 ### Outputs
 
-Should be consistent with state names.
+(These are mostly an internal concept; just make consistent with task states)
 
-| old             | new :question:      | meaning       | comment |
-|----             |----                 | ---           | ---     | 
-| expired         | -                   | (see states)  |         |
-| submitted       | -                   | (see states)  |         |
-| submit-failed   | submission-failed   | (see states)  |         |
-| started         | executing           | (see states)  | or execution-started? |
-| succeeded       | execution-succeeded | (see states)  |          |
-| failed          | execution-failed    | (see states)  |          |
+| current           | new             |
+|---                |----             |
+| `expired`         | `expired`       |
+| `submitted`       | `submitted`     |
+| `submit-failed`   | `submit-failed` |
+| `started`         | `run-started`   |
+| `succeeded`       | `run-succeeded` |
+| `failed`          | `run-failed`    |
+| (custom)          | (custom)        |
+
+Notes:
+- added `run-` prefixes for consistency and to avoid any ambiguity
 
 ### Graph Trigger Qualifiers
 
-Should be consistent with state names.
+| old                  | new              |
+|----                  |----              |
+| `:expire[d]`         | `:expired`       |
+| `:submit[ted]`       | `:submitted`     |
+| `:submit-fail[ed]`   | `:submit-failed` |
+| `:start[ed]`         | `:started`       |
+| `:succeed[ed]`       | `:[run-]succeeded` (default) |
+| `:fail[ed]`          | `:[run-]failed`  |
+| :(custom)            | :(custom)      |
 
-However, abbreviating long names is desirable in graph configuration. (The
-current aliasing - optional "ed" suffix - is not necessary though).
+Notes:
+- `run-` added to disambiguate, and for consistency with state names
+- however, `run-succeeded` is the default so will rarely be used explicitly;
+  and we'll need to support the old/abbreviated names for back-compat anyway
 
-| old                | new :question:       | abbrev :question:  | meaning      | comment  |
-|----                |----                  |----                | ---          | ---      | 
-| :expire[d]         | :expired             | :expired           | (see states) |          |
-| :submit[ted]       | :submitted           | :submitted         | (see states) |          | 
-| :submit-fail[ed]   | :submission-failed   | :sub-failed        | (see states) |          | 
-| :start[ed]         | :executing           | :executing         | (see states) | or execution-started?  | 
-| :succeed[ed]       | :execution-succeeded | :exe-succeeded     | (see states) | DEFAULT (no qualifier) | 
-| :fail[ed]          | :execution-failed    | :exe-failed        | (see states) |          | 
-| :(label)           | -                    | -                  | custom message output   |
+### Implementation Plan
+
+(Roughly; can be refined on appropriate Issue or PR pages)
+
+Code
+- rename states throughout the code base, including functional tests, using
+  constants defined in one place
+- deal with absorption of `queued` into `waiting`
+- (TODO: do we still need the "retry(ing?)" event - probably OK as it triggers
+  when a retrying task submits, and distinguishes original try from retries).  
+- create back-compat tests 
+- write code to support interrogation of a waiting task's queue status
+
+User Guide
+- rename states throughout, document their meanings and relation to cylc-7 states
+
+UI
+- need a new `preparing` task icon
+- new new "held" and "queued" badges/icons 
+  - graph view: represent as dependencies (like xtriggers in cylc 7 GUI)
+    (diagram: https://github.com/cylc/cylc-admin/pull/47#issuecomment-531849902)
+  - other views: represent as badges on top of the task state icon
+- (allow interrogation of a waiting task's queue status)

--- a/docs/proposal-state-names.md
+++ b/docs/proposal-state-names.md
@@ -14,14 +14,14 @@ grammatically inconsistent.
 |----             |----               | ---     | ---     | 
 | runahead        | -                 | beyond "max active cycle points" | (not needed in spawn-on-demand future) |
 | waiting         | -                 | waiting for prerequisites to be met |
-| queued          | limited           | held back in a limited internal queue | **queued** gets confused with batch queue! |
-| ready           | submitting        | in the process pool for job submission | | 
+| queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
+| ready           | submitting        | queued to the subprocess pool for job submission | | 
 | expired         | -                 | waiting for too long, will never be submitted | | 
 | submitted       | -                 | job submitted to batch system for execution | | 
 | submit-failed   | submission-failed | job submission failed, did not execute | | 
 | submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted |
 | running         | executing         | job execution commenced | | 
-| succeeded       | -                 | job execution completed successfully | | 
+| succeeded       | execution-succeeded | job execution completed successfully | | 
 | failed          | execution-failed  | job execution completed, but failed | | 
 | retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing | 
 | held | - | held back even if ready to submit | (not actually a task state in Cylc 8) |
@@ -41,15 +41,17 @@ Should be consistent with state names.
 
 ### Graph Trigger Qualifiers
 
-Should be consistent with state names. Current aliasing (optional "ed"
-suffix) is really not necessary.
+Should be consistent with state names.
 
-| old                | new :question:       | meaning      | comment  |
-|----                |----                  | ---          | ---      | 
-| :expire[d]         | :expired             | (see states) |          |
-| :submit[ted]       | :submitted           | (see states) |          | 
-| :submit-fail[ed]   | :submission-failed   | (see states) |          | 
-| :start[ed]         | :executing           | (see states) | or execution-started? | 
-| :succeed[ed]       | :execution-succeeded | (see states) |          | 
-| :fail[ed]          | :execution-failed    | (see states) |          | 
-| :(label)           | -                    | custom message output | |
+However, abbreviating long names is desirable in graph configuration. (The
+current aliasing - optional "ed" suffix - is not necessary though).
+
+| old                | new :question:       | abbrev :question:  | meaning      | comment  |
+|----                |----                  |----                | ---          | ---      | 
+| :expire[d]         | :expired             | :expired           | (see states) |          |
+| :submit[ted]       | :submitted           | :submitted         | (see states) |          | 
+| :submit-fail[ed]   | :submission-failed   | :sub-failed        | (see states) |          | 
+| :start[ed]         | :executing           | :executing         | (see states) | or execution-started?  | 
+| :succeed[ed]       | :execution-succeeded | :exe-succeeded     | (see states) | DEFAULT (no qualifier) | 
+| :fail[ed]          | :execution-failed    | :exe-failed        | (see states) |          | 
+| :(label)           | -                    | -                  | custom message output   |

--- a/docs/proposal-state-names.md
+++ b/docs/proposal-state-names.md
@@ -10,25 +10,28 @@ grammatically inconsistent.
 
 ### Task and Job States
 
-| Job?  | old name          | new name :question:    | meaning | comment |
-|--   | --             |----               | ---     | ---     | 
-|     | waiting         | -                 | waiting for prerequisites to be met |
-|     | queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
-|     | ready           | submitting        | queued to the subprocess pool for job submission | | 
-|     | expired         | -                 | waiting for too long, will never be submitted | | 
+| Job?  | old name      | new name :question: | meaning | comment |
+|--     | --              |----               | ---     | ---     | 
+|       | runahead        |  -                | in the runahead pool (too far ahead) | |
+|       | waiting         | -                 | waiting for prerequisites to be met |
+|       | queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
+|       | ready           | submitting        | queued to the subprocess pool for job submission | | 
+|       | expired         | -                 | waiting for too long, will never be submitted | | 
 | :heavy_check_mark:  | submitted       | -                 | job submitted to batch system for execution | | 
 | :heavy_check_mark:  | submit-failed   | submission-failed | job submission failed, did not execute | | 
-|     | submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted |
+|     | submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted (TODO: REMOVE) |
 | :heavy_check_mark:  | running         | executing         | job execution commenced | | 
 | :heavy_check_mark:  | succeeded       | execution-succeeded | job execution completed successfully | | 
 | :heavy_check_mark:  | failed          | execution-failed  | job execution completed, but failed | | 
-|     | retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing | 
+|     | retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing (TODO: REMOVE) | 
 
 Note:
-- ("held" removed - demoted from state to attribute in Cylc 8)
-- ("runahead" - i.e. beyond "max active cycle points" - removed; it is a task pool
-  implmentation detail that should not be exposed to users, and it will not
-  exist in the spawn-on-demand era)
+- ("held" no longer a task state - demoted from state to attribute in Cylc 8)
+- "runahead" is really implementation that should not be exposed, and will not
+  exist in the spawn-on-demand era, but so long as we still have a task pool
+  users occasionally need to understand it (e.g. if they `cylc insert` a task
+  beyond "max active cycle points").
+- The "retry" states are to be removed as for "held"
 
 ### Outputs
 

--- a/docs/proposal-state-names.md
+++ b/docs/proposal-state-names.md
@@ -1,0 +1,55 @@
+# Proposal
+
+## Rationalise Task State, Output, and Trigger Names
+
+REF: https://github.com/cylc/cylc-ui/pulls#issuecomment-521121132
+
+Cylc has gradually accrued new task states and associated triggers and outputs
+over the years, and the resulting names are variously ambiguous, confusing, or
+grammatically inconsistent.
+
+### Task (and Job) States
+
+| old             | new :question:    | meaning | comment |
+|----             |----               | ---     | ---     | 
+| runahead        | -                 | beyond "max active cycle points" | (not needed in spawn-on-demand future) |
+| waiting         | -                 | waiting for prerequisites to be met |
+| queued          | limited           | held back in a limited internal queue | **queued** gets confused with batch queue! |
+| ready           | submitting        | in the process pool for job submission | | 
+| expired         | -                 | waiting for too long, will never be submitted | | 
+| submitted       | -                 | job submitted to batch system for execution | | 
+| submit-failed   | submission-failed | job submission failed, did not execute | | 
+| submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted |
+| running         | executing         | job execution commenced | | 
+| succeeded       | -                 | job execution completed successfully | | 
+| failed          | execution-failed  | job execution completed, but failed | | 
+| retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing | 
+| held | - | held back even if ready to submit | (not actually a task state in Cylc 8) |
+
+### Outputs
+
+Should be consistent with state names.
+
+| old             | new :question:      | meaning       | comment |
+|----             |----                 | ---           | ---     | 
+| expired         | -                   | (see states)  |         |
+| submitted       | -                   | (see states)  |         |
+| submit-failed   | submission-failed   | (see states)  |         |
+| started         | executing           | (see states)  | or execution-started? |
+| succeeded       | execution-succeeded | (see states)  |          |
+| failed          | execution-failed    | (see states)  |          |
+
+### Graph Trigger Qualifiers
+
+Should be consistent with state names. Current aliasing (optional "ed"
+suffix) is really not necessary.
+
+| old                | new :question:       | meaning      | comment  |
+|----                |----                  | ---          | ---      | 
+| :expire[d]         | :expired             | (see states) |          |
+| :submit[ted]       | :submitted           | (see states) |          | 
+| :submit-fail[ed]   | :submission-failed   | (see states) |          | 
+| :start[ed]         | :executing           | (see states) | or execution-started? | 
+| :succeed[ed]       | :execution-succeeded | (see states) |          | 
+| :fail[ed]          | :execution-failed    | (see states) |          | 
+| :(label)           | -                    | custom message output | |

--- a/docs/proposal-state-names.md
+++ b/docs/proposal-state-names.md
@@ -8,23 +8,27 @@ Cylc has gradually accrued new task states and associated triggers and outputs
 over the years, and the resulting names are variously ambiguous, confusing, or
 grammatically inconsistent.
 
-### Task (and Job) States
+### Task (T) and Job (J) States
 
 | old             | new :question:    | meaning | comment |
 |----             |----               | ---     | ---     | 
-| runahead        | -                 | beyond "max active cycle points" | (not needed in spawn-on-demand future) |
-| waiting         | -                 | waiting for prerequisites to be met |
-| queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
-| ready           | submitting        | queued to the subprocess pool for job submission | | 
-| expired         | -                 | waiting for too long, will never be submitted | | 
-| submitted       | -                 | job submitted to batch system for execution | | 
-| submit-failed   | submission-failed | job submission failed, did not execute | | 
-| submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted |
-| running         | executing         | job execution commenced | | 
-| succeeded       | execution-succeeded | job execution completed successfully | | 
-| failed          | execution-failed  | job execution completed, but failed | | 
-| retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing | 
-| held | - | held back even if ready to submit | (not actually a task state in Cylc 8) |
+| T   waiting         | -                 | waiting for prerequisites to be met |
+| T   queued          | limited           | held back by a size-limited internal queue | **queued** gets confused with "submitted" (to a batch queue)! |
+| T   ready           | submitting        | queued to the subprocess pool for job submission | | 
+| T   expired         | -                 | waiting for too long, will never be submitted | | 
+| T/J submitted       | -                 | job submitted to batch system for execution | | 
+| T/J submit-failed   | submission-failed | job submission failed, did not execute | | 
+| T/J submit-retrying | submission-retry  | job submission failed, will try again later | retry**ing** suggests already re-submitted |
+| T/J running         | executing         | job execution commenced | | 
+| T/J succeeded       | execution-succeeded | job execution completed successfully | | 
+| T/J failed          | execution-failed  | job execution completed, but failed | | 
+| T   retrying        | execution-retry   | job execution failed, will try again later | retry**ing** suggests already re-executing | 
+
+Note:
+- ("held" removed - demoted from state to attribute in Cylc 8)
+- ("runahead" - i.e. beyond "max active cycle points" - removed; it is a task pool
+  implmentation detail that should not be exposed to users, and it will not
+  exist in the spawn-on-demand era)
 
 ### Outputs
 


### PR DESCRIPTION
REF: https://github.com/cylc/cylc-ui/pulls#issuecomment-521121132 (and follow-up comment from @matthewrmshin )

*Cylc has gradually accrued new task states and associated triggers and outputs over the years, and the resulting names are variously ambiguous, confusing, or grammatically inconsistent.*