### PR TITLE
Update the rose-suite-run proposal and add a separate platforms proposal

### DIFF
--- a/docs/proposal-platforms.md
+++ b/docs/proposal-platforms.md
@@ -1,0 +1,298 @@
+# Proposal - initial support for platforms
+
+This will close [cylc-flow #3421](https://github.com/cylc/cylc-flow/issues/3421)
+and partially address
+[cylc-flow #2199](https://github.com/cylc/cylc-flow/issues/2199).
+
+## Key functionality
+
+* Introduce configuration and logic to recognise compute platforms in place of
+  task hosts. This will resolve a number of issues.
+  * In particular, this allows a compute cluster which can be accessed via
+    multiple login nodes (hosts) to be treated as logical unit.
+  * We will be able to configure multiple platforms which share the same hosts
+    (including `localhost`).
+
+* If a platform has a list of hosts then the host used for each operation on that
+  platform (job submission, polling, log retrieval, etc) will be randomised. This
+  should help balance the load. If a host becomes unavailable, try another random
+  host from the list, until exhausted. This will handle hosts becoming
+  unavailable after a job is submitted which is a major limitation of the current
+  logic.
+
+* It will be possible to specify the platform for a task as a platform alias
+  which defines a list of platforms. For example, you may have 2 different HPC
+  systems (configured as separate "platforms") and you are happy for a task to
+  run on either. The list will be randomised and the platforms tried in turn
+  until successful job submission.
+  * Note that the platform will be selected each time a job is run. If you
+    specify a platform alias which defines a list of platforms, tasks must not
+    assume that retries of that task will use the same platform.
+
+* It will be possible to specify the platform as a command in the same way as we
+  can currently specify hosts as a command. The command must return a valid
+  platform (or platform alias). We hope that this functionality will seldom be
+  needed in the future (the main use at present is to select from a list of login
+  nodes). However, there are still cases where this may be needed. For example
+  running a command which:
+  * Returns the platform which has the shortest queue time.
+  * Chooses the platform according to the day of the week (perhaps you have a
+    platform which can only be used at weekends?).
+
+* Note: it will **not** be possible to specify the platform as an environment
+  variable in the same way as we can currently specify remote hosts as an
+  environment variable (e.g. `platform = $ROSE_ORIG_HOST`).
+  * Unclear why we need this given the Jinja2 variables can be used?
+  * Using `$ROSE_ORIG_HOST` relies on Rose specifying extra options to set this
+    in `[cylc][environment]` which we should avoid if possible.
+
+## Example platform configurations
+
+```ini
+[platforms]
+    [[desktop\d\d|laptop\d\d]]
+        # hosts = platform name (default)
+        # Note: "desktop01" and "desktop02" are both valid and distinct platforms
+    [[sugar]]
+        hosts = localhost
+        batch system = slurm
+    [[hpc]]
+        hosts = hpcl1, hpcl2
+        retrieve job logs = True
+        batch system = pbs
+    [[hpcl1-bg]]
+        hosts = hpcl1
+        retrieve job logs = True
+        batch system = background
+    [[hpcl2-bg]]
+        hosts = hpcl2
+        retrieve job logs = True
+        batch system = background
+[platform aliases]
+    [[hpc-bg]]
+        platforms = hpcl1-bg, hpcl2-bg
+```
+
+Note:
+
+* The default for `hosts` is the platform name and platform section headings can
+  be regular expressions to match multiple platform names. This allows us to
+  define many platforms in a single section and handles the case where you have
+  a large number of separate servers which are identical in terms of their
+  platform properties other than their host name.
+
+* The current logic for finding matching host settings is complicated and not
+  fully
+  [documented](https://cylc.github.io/doc/built-sphinx/appendices/site-user-config-ref.html#hosts-host)
+  (sections defining individual host names take precedence over pattern matches
+  regardless of where they come in the order). We propose a different logic for
+  finding matching platform settings:
+  * The pattern will be matched against the full name using
+    [re.fullmatch](https://docs.python.org/3/library/re.html#re.fullmatch)
+    (rather then `re.match` which is currently used for matching hosts).
+  * A hierarchy of platform match expressions from general to specific can be
+    used because config items are processed in the reverse order specified in the
+    file (i.e. bottom up). This is opposite to the method currently used for
+    matching hosts but is required because any additional platforms defined in
+    user config files get added to the end of the list. Currently it is
+    impossible to add hosts defined as regular expressions in the user config if
+    there is already a more generic regular expression defined in the global
+    config.
+  * There will be no special treatment of sections which define a single
+    platform. The first matching section found will be used.
+  * Note that the first reference to a section in the global or user config
+    determines its position in the list. You can repeat a section later in the
+    config and alter some settings but this doesn't change its position.
+
+* The names of all new and existing settings are subject to change until we
+  release cylc 8.0. Initially names will be chosen which match current usage
+  wherever possible. We intend to review all the config settings once we have
+  the key functionality in place.
+
+* The default platform is `localhost`. At cylc 7, any settings for `localhost`
+  act as defaults for all other hosts but we do **not** propose doing this for
+  platforms. The downside is more duplication if you need to override a
+  particular setting for every platform but we think this is clearer and safer.
+
+* If `hosts` is defined then the platform section heading should specify a single
+  platform name - otherwise you are defining lots of identical platforms which
+  makes no sense (although it is relatively harmless so we probably won't try to
+  prevent this or give any warnings if this happens).
+  * As a future enhancement we could support the use of string substitution using
+    [re.sub](https://docs.python.org/3/library/re.html#re.sub) (this would make
+    the deprecation logic more complicated so we don't propose doing this at
+    first). e.g. something like:
+```ini
+[platforms]
+    [[hpcl[12]-bg]]
+        hosts = ("-bg$","") # or "hosts = s/-bg$//" ?
+        retrieve job logs = True
+        batch system = background
+```
+
+## Example platform usage
+
+These are examples of how the platform may be assigned in the `[runtime]`
+section for a job. They refer to the example platforms shown above.
+
+`platform = desktop01`
+* The simplest example. The job will be run on the host `desktop01`.
+
+`platform = special`
+* There is no platform named `special` defined so this will fail validation.
+
+`platform = hpc`
+* The host used will be chosen at random.
+
+`platform = hpc-bg`
+* The platform used will be chosen at random ("hpcl1" or "hpcl2").
+
+`platform = $(rose host-select linux)`
+* No checking can be performed at validation so if the command does not return a
+  valid platform this will result in a submit failure.
+
+## Deprecation method
+
+* You can't mix old with new. If `platform` is defined for **any** task then any
+  settings in the `[remote]` or `[job]` sections of **any** task result in a
+  validation failure.
+
+* Any settings in the `[remote]` or `[job]` sections which have equivalent
+  settings in the new runtime section are converted using the normal deprecate
+  method. e.g. `[job] execution time limit`.
+
+* The remaining `[remote]` & `[job]` settings are converted by searched for a
+  matching platform. If there is none the conversion fails resulting in an
+  error.
+
+* For fixed remote hosts the conversion happens at load time and the lack of a
+  matching platform results in a validation failure.
+
+* For remote hosts defined as a command or an environment variable the
+  remaining `[remote]` & `[job]` settings are stored and the conversion happens
+  at job submission. In this case the lack of a matching platform results in a
+  submission failure.
+
+* The `[remote] host` setting is matched first by checking the platforms
+  `hosts` setting. If this is not defined then the match is made against
+  the valid platform names.
+  * We may need special logic so that if `[remote] host` is set to the workflow
+    server hostname then this is converted to `localhost` before matching
+    occurs.
+
+## Deprecation examples
+
+```ini
+[runtime]
+    [[alpha]]
+        [[[remote]]]
+            host = localhost
+        [[[job]]]
+            batch system = background
+        # => platform = localhost (set at load time)
+
+    [[beta]]
+        [[[job]]]
+            batch system = slurm
+        # => platform = sugar (set at load time)
+
+    [[gamma]]
+        [[[remote]]]
+            host = $(rose host-select hpc)
+            # assuming this returns "hpcl1" or "hpcl2"
+        [[[job]]]
+            batch system = pbs
+        # => platform = hpc (set at job submission time)
+
+    [[delta]]
+        [[[remote]]]
+            host = hpcl1
+        [[[job]]]
+            batch system = background
+        # => platform = hpcl1-bg (set at load time)
+```
+
+## Enhancements to support rose suite-run functionality
+
+Several additions to the platform support will be needed to support rose
+suite-run functionality:
+
+1. Installation of suites on platforms
+   * We already have logic to install service files on remote platforms just
+     before the first set of jobs is submitted to each platform after suite
+     start-up or on suite reload. This system needs to be extended to other
+     items of the suite.
+   * Consider whether we can make this work on a filesystem rather than a
+     platform basis?
+     * Configure the id of the filesystem used on a particular platform
+       (defaults to the platform name).
+     * If multiple platforms share the same root filesystem then use a common
+       id.
+     * Would need to consider the case where the root filesystem is shared but
+       log, work or share differ.
+
+2. Support for moving the share, work & log directories to different locations
+   with optional symlinks to the root directory. Similarly support for moving
+   the root directory with symlink to the `cylc-run` directory.
+
+## Further enhancements
+
+There are a number of ideas for enhancements (some of which are referenced in
+[cylc-flow #2199](https://github.com/cylc/cylc-flow/issues/2199)) which we will
+not attempt to address in the initial implementation. These include:
+
+* Specify whether the root filesystem on a platform is shared with the workflow
+  server. Currently it is assumed to be separate so installation is attempted on
+  all remote hosts. There is logic to detect that it is shared but it would be
+  more efficient to configure this. Note: already covered if we install on a
+  filesystem basis as discussed above.
+
+* Define default directives for all jobs on a platform.
+
+* Support task management commands (kill, poll) by platform.
+
+* Hold all tasks that target a particular platform.
+  * How would this work with platform aliases and platforms specified via
+    commands?
+
+* Limit the number of jobs submitted to a platform at any one time.
+
+* Custom logic to invoke for collecting job accounting information when a job
+  completes.
+
+* If a platform has a list of hosts, support other methods for choosing which
+  host to use (rather than just random) using the functionality already
+  implemented for selecting the workflow server host.
+  * Since we are not running resource intensive commands on these hosts it's not
+    clear whether this functionality is really needed?
+  * Note that we can't simply use the existing funtionality for the random host
+    selection since we need to try each host in turn until the job submission
+    suceeeds (rather than choose a single host to attempt the job submission).
+
+* If a platform alias has a list of platforms, support other methods for choosing
+  which platform to use (rather than just random).
+  * Platform aliases can then replace all the current use cases for
+    `rose host-select`.
+  * We could simply allow `platforms` to be specified as a command? This would
+    provide an alternative to specifying a platform as a command in the suite
+    (configure a platform alias instead).
+
+* The `[suite servers]` section is configuring something very similar to a
+  platform alias. Should we try to unify the approach (i.e specify the suite
+  servers as a platform)?
+
+* Support the use of string substitution to derive the host from the platform
+  name (discussed above).
+
+* Support platform inheritance so that you can define a platform based on an
+   existing platform to reduce duplication. e.g.
+```ini
+[platforms]
+    [[hpcl1-bg]]
+        inherit = hpc
+        hosts = hpcl1
+        batch system = background
+```
+
+Note that these are just ideas for possible enhancements - no assumptions are
+made at this stage as to which ones are worth implementing.

--- a/docs/proposal-platforms.md
+++ b/docs/proposal-platforms.md
@@ -161,9 +161,9 @@ section for a job. They refer to the example platforms shown above.
   settings in the new runtime section are converted using the normal deprecate
   method. e.g. `[job] execution time limit`.
 
-* The remaining `[remote]` & `[job]` settings are converted by searched for a
-  matching platform. If there is none the conversion fails resulting in an
-  error.
+* The remaining `[remote]` & `[job]` settings are converted by searching for a
+  platform which matches **all** the items set. If there is none the conversion
+  fails resulting in an error.
 
 * For fixed remote hosts the conversion happens at load time and the lack of a
   matching platform results in a validation failure.
@@ -192,11 +192,18 @@ section for a job. They refer to the example platforms shown above.
         # => platform = localhost (set at load time)
 
     [[beta]]
+        [[[remote]]]
+            host = desktop01
+        [[[job]]]
+            batch system = slurm
+        # => validation failure (no matching platform)
+
+    [[gamma]]
         [[[job]]]
             batch system = slurm
         # => platform = sugar (set at load time)
 
-    [[gamma]]
+    [[delta]]
         [[[remote]]]
             host = $(rose host-select hpc)
             # assuming this returns "hpcl1" or "hpcl2"
@@ -204,7 +211,14 @@ section for a job. They refer to the example platforms shown above.
             batch system = pbs
         # => platform = hpc (set at job submission time)
 
-    [[delta]]
+    [[epsilon]]
+        [[[remote]]]
+            host = $(rose host-select hpc)
+        [[[job]]]
+            batch system = slurm
+        # => job submission failure (no matching platform)
+
+    [[zeta]]
         [[[remote]]]
             host = hpcl1
         [[[job]]]

--- a/docs/proposal-rose-suite-run.md
+++ b/docs/proposal-rose-suite-run.md
@@ -1,271 +1,104 @@
 # Proposal - rose suite-run functionality migration to cylc
 
-## Goals
-
-Complete [cylc/cylc#1885](https://github.com/cylc/cylc/issues/1885)
-
-## Synopsis
-
 The work described in this document aims to:
-* Deprecate `rose suite-run`.
-* Provide a new cylc command to replace `rose suite-run`.
 * Change the way hosts for jobs are selected to improve support for clusters.
-* Rationalize the formats of settings `*.rc` files.
+* Deprecate `rose suite-run` and provide a new cylc command to replace it.
 
-
-## Background
-
-In the early days of Rose, there was the desire for Rose to be an umbrella
-system that would drive multiple workflow engines. The command `rose suite-run`
-was written as a top level utility that was supposed to work with Cylc as well
-as other workflow engines. It was designed with extra functionalities that
-would appeal to users who also use other parts of Rose. It was thought that
-the design would allow Cylc to maintain its independence from these
-functionalities of Rose.
-
-In reality, Cylc has become the centre of the Rose application suites, and the
-extra functionalities provided by Rose are equally desirable on sites who
-choose not to use Rose.
-
-The logical step is therefore to move these extra functionalities provided by
-Rose into Cylc - and retire `rose suite-run` and related utilities - so that
-all suites will start up with only Cylc commands in the future.
+This will complete [cylc-flow #1885](https://github.com/cylc/cylc-flow/issues/1885).
 
 ## Work Plan
 
-- [ ] Agree future form of `cylc-flow.rc` 
-  - [x] Create new issue against cylc-admin [Cylc-Admin #43](https://github.com/cylc/cylc-admin/issues/43)
-  - [x] Create [detailed specification for the new `.rc` file](rose-suite-run-proposal/cylc-flow-rc.md).
-  - [ ] Create new [`config-schema.py` (PR3348)](https://github.com/cylc/cylc-flow/pull/3348)
+1. Implement basic platforms support.
+   See [platforms proposal](proposal-platforms.md).
 
-- [ ] Implement new `cylc-flow.rc` schema. [Cylc-flow #3260](https://github.com/cylc/cylc-flow/issues/3260)
-  - [ ] Modify enough of the code to allow basic validation of new __or__ old configs.
-  - [ ] Add the upgraders needed to make a valid cylc 7.x `suite.rc` validate sensibly at cylc8
-  - [ ] Create new tests under `tests/deprecations` and `tests/validate` to check that the
-        new schema can be validated.
-  - [ ] Ensure that the global config can be parsed too!
-  - [ ] Remove the `cylc.flow.cfgspec` folder.
+2. Add new platforms features required to support rose suite-run functionality.
+   See [platforms proposal](proposal-platforms.md#enhancements-to-support-rose-suite-run-functionality).
 
+3. Define new cylc command to replace rose suite-run (and adapt rose suite-run
+   to provide backwards compatibility). See [below](#replacing-rose-suite-run).
 
-- [ ] Implement Cluster support functionality. [Cylc-flow #2199](https://github.com/cylc/cylc-flow/issues/2199)
-  - [ ] Modify modules to use the new variables:
-    - [ ]  `task_job_mgr.py`
-    - [ ] `task_remote_mgr`    
-  - [ ] Randomize login host used
+The remaining points can happen any time after 1) is complete although note that
+2) and 3) are higher priority.
 
+5. Support generation of cylc config reference documentation from the code and
+   ensure all settings are documented.
+   See [cylc-doc #11](https://github.com/cylc/cylc-doc/issues/11).
+   Alternatively, review and update the existing documentation.
 
-- [ ] Agree names and functionality of future `cylc flow`(working name)
-  command and command args.[#1030](https://github.com/cylc/cylc-flow/issues/1030)
-  - [ ] Summarize debate on ticket.
-  - [ ] Create a PR against cylc-admin creating a specification for `cylc flow`
+6. Implement further enhancements to the platforms support.
+   See [platforms proposal](proposal-platforms.md#further-enhancements).
+   Note that these are not essential for Cylc 8.0.
 
+7. Review all config settings and make any agreed changes.
+   See [cylc-flow #3422](https://github.com/cylc/cylc-flow/issues/3422).
+   Note that these are not essential for Cylc 8.0 although we should try to
+   address any non-controversial changes.
 
-- [ ] Create a `cylc flow` CLI.
-  - [ ] Include suite validation in `cylc flow` CLI.
+## Replacing rose suite-run
 
+### Key Functionality
 
-- [ ] Replace `rose-suite.conf`.
-  - [ ] Create an alternative python config file and tests for
-    these format.
-  - [ ] Create a cylc plugin to maintain back compatibility by parsing
-    rose-suite.conf
+1. Installation of suites on platforms and support for moving the share, work &
+   log directories to different locations. Currently this is done by
+   `rose suite-run` but we will include this in the
+   [platforms support](proposal-platforms.md#enhancements-to-support-rose-suite-run-functionality).
 
+2. On start up and reload, install the suite from the source location (working
+   copy) to the run location (`cylc-run`).
+   * Currently this functionality assumes a shared filesystem but we should
+     support workflow server hosts with separate filesystems (future
+     enhancement?).
+   * Needs to create the run time directory structure which has been configured
+     for the `localhost` platform.
 
-## Functionalities to Consider
+3. On start up, housekeep / archive logs and other items generated by the suite.
 
-These functionalities are currently provided by Rose, but should really be part
-of Cylc:
+4. On start up and reload, validate suite (using `--strict`).
+   * Hopefully this can become a standard part of suite start-up rather than a
+     separate step. This was difficult previously because cylc loads the suite
+     after it has been detached?
+   * Consider making all validation strict? If we want really want to allow
+     naked dummy tasks in some circumstances then we would be better to add a
+     suite configuration for this.
 
-* On start up and reload, install suite on suite server cluster (cylc servers).
-* On start up and reload, validate suite.
-* On start up, archive old log directory.
-* On start up and reload, install suite on all task job remotes (such as Cray,
-  Spice, remote-desktop, raspi, suite-origin-desktop).
-* Utility to clean locations that are known to be created by the suite.
-* On starting up a new run of the suite assign a new run name:
-  ```
-  mi-aa001/
-    run1
-    run2
-  ```
+5. Handle `rose-suite.conf` functionality
+   * Pull items from other locations / sources on installation (e.g. svn).
+   * Configure Jinja2 / EmPy inputs.
+   * Set environment variables exported to the suite daemon?
+   * Continue to handle `rose-suite.conf` using a plugin preprocessor.
+   * Decide which features to support natively in Cylc and how.
 
-While we consider the above, we may also want to consider the following:
-* Introduce configuration and logic to recognise suite clusters and task hosts
-  as logical units (e.g. pools of identical servers, HPCs, compute clusters).
-  Instead of working with remote hosts, we'll work with local and remote
-  compute clusters/platforms.
-* Rationalise run/restart/reload CLI/API? E.g. A single command to unify
-  `cylc run` and `cylc restart`, with a cleaner set of options and arguments.
-* Rationalise related settings from `suite.rc`, `global.rc`, `rose-suite.conf`:
-  * Sections and keys should be idenitical between `flow.rc`
-    (`global-flow.rc`?) in a global location and a suite `flow.rc` (`suite-
-      flow.rc`?) in the suite folder.
-  * This combined file should prefer to maintain compatibility with `suite.rc`
-    for ease of end user upgrade. Users of `global.rc` are generally
-    administrators.
-  * Although the aim is to make the the two files the same, it is not likely
-    that normal users will use all the available settings in both. It is
-    expected that in most cases local and global rc have partially overlapping
-    subsets of settings:
-    ![Venn Diagram showing expected common usage](img/flow_rc_settings_locs.svg)
-  * Migrate relevant settings from `rose.conf` and `rose-suite.conf`.
-    __UPDATE THIS__
-  * Settings such as `run directory` and `work directory` may need better names
-    (users think of "work" as a sub-directory of the run directory, but `run
-    directory` and `work directory` are configured separately, and the latter
-    (work directory) is actually the top level (run directory) location under
-    which to put the work directory ... and it may confuse users that a
-    non-standard run directory does bring the work directory with it).
+6. Utility to remove installed locations (on all platforms) on demand
+   (equivalent to `rose suite-clean`).
 
-### Clusters instead of Hosts as Logical Units
+7. On starting up a new run of the suite assign a new run name:
+   ```
+   mi-aa001/
+     run1
+     run2
+   ```
+   * This is new functionality but Cylc 8 is a good time to introduce it.
+   * Use a symbolic link to identify the latest run which is the default name
+     when performing operations on a suite?
 
-Modern compute resources come in clusters of one or more serving host(s).
-A basic assumption is that the serving hosts of a typical cluster
-share the same storage units and a single workload management system.
+8. Consider the behaviour created by the `CYLC_VERSION` and `ROSE_VERSION`
+   variables in `rose-suite.conf`. These allow rose suite-run to:
+   * Change the version of Cylc and check the version of Rose used to run the
+     suite.
+   * Prevent suites accidentally upgrading or downgrading versions on restart.
 
-The current configuration in Cylc (and Rose) allows us to configure settings by
-host names, but not by the clusters. There are some immediate issues:
-* For clusters with multiple login hosts, remote task host management logic
-  would consider the multiple login hosts separately - when it only
-  really needs to consider one of the available login hosts.
-* Suite hosts may happen to be the access hosts for a compute cluster - so it
-  is currently difficult to configure separate logic for such a compute cluster
-  without affecting the suite cluster.
-* Multiple clusters may share the same set of access hosts. (This creates a
-  similar problem as above.)
-* The `localhost` settings in the current code restrict what we can do when we
-  have a cluster of suite hosts.
+9. Consider `rose prune` functionality.
+   * Need to make sure it will continue to work correctly.
+   * Need Cylc equivalent but this should be done as part of
+     [cylc-flow #1159](https://github.com/cylc/cylc-flow/issues/1159).
 
-The most logical way to support installation of suites on suite clusters and
-job hosts is to migrate our host-based configuration logic to a cluster-based
-configuration logic. Some points to consider:
-* Deprecate `global.rc` `[hosts]` section in favour of a `[job platforms]`
-  section. The new section should allow us to configure:
-  * Login hosts.
-  * Batch system or workload manager, and related settings.
-  * Directory locations for various usages by suites.
-  * Communication protocols:
-    * Forward (install, submit, poll, kill, view log, log retrieval, etc).
-    * Backward (message and manipulation commands).
-* Deprecate `suite.rc` relevant settings under `[runtime][__MANY__]`, but have
-  a top level `[job platforms]` section that simply mirrors that of `global.rc` to allow individual suites to override the site/user settings.
-* Users will configure tasks to run on clusters instead of hosts/batch systems.
-* If relevant, improve alignment with DRMAA Open Grid Forum API?
+### CLI
 
-
-So, for example, a suite `suite-flow.rc` might look like this:
-(Although a detailed specification should also be created)
-```ini
-[cylc]
-
-    ...
-
-[scheduling]
-    ...
-
-[job platforms]
-    [[spice]]
-        [[[batch system]]]
-            class = slurm
-            before command = sshare -u %(user_id)           # Blue Sky thinking
-            after command = sacct -j %(jobid)s --format=""
-    [[xcs]]
-        login hosts = xcslr0, xcslr1
-        retrieve job logs = True
-        [[[batch system]]]
-            class = pbs
-        [[[default directives]]]
-            --some-directive="directive here!"
-    [[desktop]]
-        login hosts = vld392
-
-[runtime]
-    [[Alice]]
-        ...
-
-    [[Bob]]
-        ...
-        [[[job platform]]]
-            platform = desktop
-
-    [[Charlie]]
-        ...
-        [[[job platform]]]
-            platform = spice
-        [[[directives]]]
-            --mem=5
-            --ntasks=1
-
-    [[Dai]]
-        ...
-        [[[job platform]]]
-            platform = cray
-```
-
-### Clusters Login Hosts Awareness
-
-While we are at it, if a cluster platform has multiple login hosts, Cylc should
-be aware so that if a login host is unavailable, it can try another one. To
-implement this, the task job management system will:
-* Randomise the list of login hosts for each cluster during run time, and
-  rotate the usage of login hosts. This should help balance the load.
-* If a login host becomes unavailable, try the next one in the list, until
-  exhausted.
-
-Other things to consider:
-* Job management commands should allow cluster-wide actions. E.g. kill all jobs
-  currently submitted to or running on a cluster.
-* New setting to configure a command to run to retrieve metrics of a completed
-  job that ran on a cluster.
-
-### Installation of Suites on Platforms
-
-We already have logic to install service files on remote platforms just before
-the first set of jobs is submitted to each platform or on suite reload. This
-system can be extended to other items of the suite. Things to consider:
-* There is no need to install suite on a platform, until just before the
-  the submission of the first remote job on that platform.
-* Install:
-  * Create directories on physical locations that are used by task jobs.
-  * Mirror suite items from suite platform to job platform.
-  * Make the above configurable.
-* Add simple command to remove suite information from installed locations on
-  demand.
-
-### Installation of Suites on Suite Cluster
-
-This is the functionality to create the run time directory structure, taking
-care of the configuration for alternate physical locations, and to install a
-suite from source to the run time location. Items can be pulled from different
-sources on installation. Other things to consider:
-* Configurable settings for directory structure and extra source locations.
-* Add ability to housekeep logs and other items generated by the suite.
-* Add equivelent functionality to `rose-suite.conf` in a native format,
-  probably a jinja2 file.
-* Continue to handle `rose-suite.conf` using a plugin preprocessor.
-* Automatic variables.
-* Add simple command to remove installed locations on demand.
-
-### Suite Validation
-
-The `rose suite-run` command calls `cylc validate --strict` by default.
-
-Automatic suite validation should become the default behaviour for the new
-command, as well as for `cylc reload`.
-
-
-### Rationalise Suite Start Up Commands
-
-This is raised in [#1030](https://github.com/cylc/cylc/issues/1030). Consider
-a single command (e.g. `cylc flow`, `cylc go`?) to with
-appropriate command switches should be agreed on in a pull
-request to this repository modifying [this document](rose-suite-run-proposal/future-cli-conventions.md)
-
-Additionally, we should consider the behaviour created by the `CYLC_VERSION`
-and `ROSE_VERSION` variables in `rose-suite.conf`. These allow rose suite-run to:
-- Check that appropriate matching versions of Rose and Cylc are being used. At
-- Change the version of Cylc and check the version of Rose used to run the suite.
-  Cylc8 this coupling will be much weaker. 
-- Pin Cylc to a given version for a suite:
-  - To prevent operational suites upgrading.
-  - To prevent upgraded suites downgrading on restart.
+We need a new Cylc command to replace `rose suite-run`.
+See [cylc-flow #1030](https://github.com/cylc/cylc-flow/issues/1030).
+* Rationalise the run/restart/reload CLI/API?
+* Existing cylc commands: `cylc run`, `cylc restart`, `cylc reload`.
+* Existing rose commands: `rose suite-run`, `rose suite-restart`.
+* Other related rose commands: `rose suite-shutdown`, `rose stem`.
+* Need to decide which commands to support for backwards compatibility?
+  Which commands can we just remove?

--- a/docs/rose-suite-run-proposal/cylc-flow-rc.md
+++ b/docs/rose-suite-run-proposal/cylc-flow-rc.md
@@ -1,4 +1,8 @@
-# Proposal example of a new style `cylc-flow.rc` file
+# Proposal - example of a new style `cylc-flow.rc` file
+
+**WARNING: this document does not reflect the latest discussions from
+[PR3348](https://github.com/cylc/cylc-flow/pull/3348) nor the latest proposals
+for [supporting platforms](../proposal-platforms.md).**
 
 ## References
 [cylc-admin PR #40](https://github.com/cylc/cylc-admin/pull/40)


### PR DESCRIPTION
Re-write of the rose suite-run proposal. The initial focus of the work will be implementing support for platforms which is now described in detail in a separate document.