### PR TITLE
Platform aliases don't need extra level

### DIFF
--- a/docs/proposal-platforms.md
+++ b/docs/proposal-platforms.md
@@ -69,8 +69,7 @@ and partially address
         retrieve job logs = True
         batch system = background
 [platform aliases]
-    [[hpc-bg]]
-        platforms = hpcl1-bg, hpcl2-bg
+    hpc-bg = hpcl1-bg, hpcl2-bg
 ```
 
 Note:


### PR DESCRIPTION
Platform aliases were originally a new subsection each containing 1 item. Why not just have those items in the section above?