### PR TITLE
proposal: mutl-user functionaltiy + cylc flow

### DIFF
--- a/docs/proposal-multi-user-approach.rst
+++ b/docs/proposal-multi-user-approach.rst
@@ -6,7 +6,7 @@ The Background
 
 Pre Cylc8 there was some level of multi-user functionality offered by Cylc.
 
-We had the "anomalous" user, the ability to scan other users suites and HTTP(s)
+We had the "anonymous" user, the ability to scan other users suites and HTTP(s)
 endpoints had authorisation levels.
 
 With the movement to the Cylc8 architecture we are planning to control suites

--- a/docs/proposal-multi-user-approach.rst
+++ b/docs/proposal-multi-user-approach.rst
@@ -1,0 +1,25 @@
+Multi-User Functionality & Cylc Flow
+====================================
+
+The Background
+--------------
+
+Pre Cylc8 there was some level of multi-user functionality offered by Cylc.
+
+We had the "anomalous" user, the ability to scan other users suites and HTTP(s)
+endpoints had authorisation levels.
+
+With the movement to the Cylc8 architecture we are planning to control suites
+via a UI Server running as the suite owner for UI purposes meaning that, from
+the Cylc Flow perspective we only need to authenticate the suite owner. All
+multi-user capability and authorisation happen at the UI Server.
+
+The Proposal
+------------
+
+Cylc Flow should be a single user application with no ability to see or
+interact with other users workflows at all.
+
+All multi-user functionality should be provided by the UI Server and, where
+applicable, made accessible to the ``cylc`` CLI tools via the GraphQL
+interface.


### PR DESCRIPTION
I think this is a decision we have already unconsciously made but one we have no record of?

Push multi-user functionality out of Cylc Flow and into the UI Server.

Formally retire the *requirement* for port scanning, anomalous authentication, etc.