### PR TITLE
platforms: leave room for rose host-select migration

### DIFF
--- a/docs/proposal-platforms.md
+++ b/docs/proposal-platforms.md
@@ -69,7 +69,10 @@ and partially address
         retrieve job logs = True
         batch system = background
 [platform aliases]
-    hpc-bg = hpcl1-bg, hpcl2-bg
+    [[hpc-bg]]
+        platforms = hpcl1-bg, hpcl2-bg
+        # other config(s) to be added here for load balancing etc
+
 ```
 
 Note:


### PR DESCRIPTION
Put each alias in a section of its own so we can configure load balancing (which would finally make `rose host-select` redundant).

```ini
[platform aliases]
    [[<alias name>]]
        platforms = list, of, platforms
        ranking = """
            # rank by available memory
            virtual_memory().available
            # exclude platforms with a load average greater than one
            getloadavg()[0] < 1
        """
```