### PR TITLE
Fix markdown link in Cylc 8 release and typos

### DIFF
--- a/docs/cylc-8-architecture.md
+++ b/docs/cylc-8-architecture.md
@@ -87,7 +87,7 @@ it is commonly used in scientific modeling and HPC contexts, See below for detai
 [Similarity with Jupyter Hub](#similarity-with-jupyterhub)).
 
 We hope to use JupyterHub "out of the box" for the Hub and Proxy components of
-the new archtitecture. Our back-end components are very different from Jupyter
+the new architecture. Our back-end components are very different from Jupyter
 Notebook, but some of the technologies involved remain relevant.
 
 
@@ -110,7 +110,7 @@ Detail:
   - A single point of access for users.
   - The only process that listens on a public interface.
   - Implemented with
-    [jupyterhub/configuable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
+    [jupyterhub/configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy)
     - ([Node.js](https://nodejs.org/); wraps
     [node-http-proxy](https://github.com/nodejitsu/node-http-proxy)).
 - Hub Authenticator: calls out to host or site identity management, with plugins for:

--- a/docs/cylc-8-roadmap.md
+++ b/docs/cylc-8-roadmap.md
@@ -156,7 +156,7 @@ https://steelkiwi.com/blog/top-10-python-web-frameworks-to-learn/):
     1. Incremental updates – can we send only what’s changed?
 1. Lists of nodes and edges (or just edges, with full nodes at each end?)?
     1. (probably can't use a nested tree structure based on runtime
-       inheritance - it would be useful for collapsible familiy views,
+       inheritance - it would be useful for collapsible family views,
        but the dependency graph can't be encoded in this form).  
 1. display "ghost nodes" in all views - i.e. hide the "task pool" from users
 
@@ -195,7 +195,7 @@ https://www.howtographql.com/react-relay/8-pagination/).
 
 ### Transition Period
 
-1. Users must continue to use the old GUI while we developg the new one 
+1. Users must continue to use the old GUI while we developing the new one 
   1. Evolve the old GUI along with the new suite API?
   1. Or support the old API as-is concurrently with the new?
   1. Or develop the cylc-8 separately on a new branch?

--- a/docs/dec-workshop-agenda.md
+++ b/docs/dec-workshop-agenda.md
@@ -128,13 +128,13 @@ Roadmap](cylc-8-roadmap) - and the other references above - for more detail.
   - Software testing, packaging and distribution
   - Scheduler prediction tool
   - Cylc packaging via `setup.py`
-  - (Begin afernoon topics, if possible)
+  - (Begin afternoon topics, if possible)
 
 - __Afternoon__
   - (BoM Cylc user feedback and discussion - if needed)
   - Deficiencies, feature requests, problem solving
   - A presentation or two, if called for
-    - e.g. the Brussels Worklfow Workshop Cylc and Rose keynote presentation?
+    - e.g. the Brussels Workflow Workshop Cylc and Rose keynote presentation?
   - Demo: Cylc with Docker (Bruno)
 
 ### Thursday

--- a/docs/feb2020-workshop-agenda.md
+++ b/docs/feb2020-workshop-agenda.md
@@ -47,7 +47,7 @@ have not been updated yet ... "suite daemon", "suite server program",
  - [Subscription Model](proposal-subscriptions.md)
  - Spawn-on-Demand (workflow evolution)
      - [Proposal](proposal-spawn-on-d.md)
-     - [POC implentation PR](https://github.com/cylc/cylc-flow/pull/3474)
+     - [POC implementation PR](https://github.com/cylc/cylc-flow/pull/3474)
  - Security
      - [BOM threat modelling notes](threats.md)
      - Cylc 7 Pen Test Report - by email

--- a/docs/feb2020-workshop-notes.md
+++ b/docs/feb2020-workshop-notes.md
@@ -103,7 +103,7 @@ Data Provision
 - what data is kept in each data store?
   - longer term the scheduler data store should become *the* scheduler state,
     so we should keep the full n=1 window, for all available data, there
-  - currently the UIS mirrors the full scheculer data store, but each
+  - currently the UIS mirrors the full scheduler data store, but each
     subscription topic is incrementally updated as content changes
   - OS: the plan was to have the UIS data store only populated according to
     the UI subscriptions.  We can still look at this as next steps, but:
@@ -146,7 +146,7 @@ Data Provision
 
 - User Preferences:
   - TODO: can the Hub DB or our own Hub Service + DB store user preferences?  
-  - authentiated users don't necessarily have an account on the back end, so we
+  - authenticated users don't necessarily have an account on the back end, so we
     should store prefs at the Hub (slightly more general than browser cookies).
   - Prefs export/input functionality for easy switch to other hubs?
   - named profiles might be needed, to associate different prefs with different
@@ -176,7 +176,7 @@ Spawn-on-Demand (HO)
 - `cylc monitor` needs to go via UIS and direct to WFS (Workflow Scheduler).
   Direct will see on n=0 (active tasks)
 - Need an "n-max" setting that will populate entire cycle points in the UI
-- Can treat succeded and failed states equally (in SoD, remove them
+- Can treat succeeded and failed states equally (in SoD, remove them
   immediately) - but we can choose (optionally?) to keep them until dismissed,
   at least until the UI has better ways to alert users to failed tasks
   - a list of failed tasks? Have to be able to retrigger from the alerting list
@@ -200,7 +200,7 @@ Spawn-on-Demand (HO)
 - (OS) "task pool" no longer a good term? (HO not so sure... now it's just a pool of active tasks.
 - (OS) TaskProxy should be renamed Job? (the Proxy class has been gutted, no
   longer doing retry logic etc.)
-- Can we unifiy outputs and prerequisites/triggers?
+- Can we unify outputs and prerequisites/triggers?
 - Reflow could be super-useful (just trigger the top task of the tree to re-run)
   - HO: need a "flow ID" passed along via the on-demand spawning mechanism
   - hard to support partial triggering by tasks from the original flow (have to
@@ -293,7 +293,7 @@ Config Item changes:
 - need ability to configure site global conf location by `CYLC_SITE_CONF_PATH` for
   cylc installations with no `/etc` access.  Default to `/etc` though.
 
-- agreed on the conf dir hierachy in the proposal (need version sub-dirs)
+- agreed on the conf dir hierarchy in the proposal (need version sub-dirs)
 
 - agreed on the "alternative" scheduler platform config proposal
 
@@ -336,7 +336,7 @@ Config Item changes:
 - `[editors]` - discourage use and make it default to `$EDITOR` and `$GEDITOR`
   (and to `vi` if those vars aren't set).
 
-- agreed to use None as config default instead of emtpy string, to allow us to
+- agreed to use None as config default instead of empty string, to allow us to
   distinguish "set to nothing" from "not set"
 
 - `disable interactive command prompts` - remove command prompts
@@ -385,8 +385,8 @@ Back-end Authentication (MH)
    - do it via ssh tunnel with ZMQ
 - (TW): need CLI-UIS for remote platforms
    - can we use a Hub API to generate tokens and use those to authenticate?
-- (JR): all messsages might need timestamps
-  - (I think we decided agains this? ... because CurveZMQ protects against replay attacks?)
+- (JR): all messages might need timestamps
+  - (I think we decided against this? ... because CurveZMQ protects against replay attacks?)
 
 Authorization
 - need site and user config
@@ -408,7 +408,7 @@ UIS Sub-services
 - (MH) Back-end Authentication 
 - Authorization method and config
 - BOM C7 pen test report relevance to C8?
-- consider and doucment BOM threat modeling points
+- consider and document BOM threat modeling points
 
 ## Thursday
 
@@ -483,7 +483,7 @@ Versioning, packaging, and deployment
 - DM: main users of the conda metapackage will be individuals not sites
 - UI dist size is not too bad now
 - Deployment by Docker?
-  - should be useable just like a conda Cylc installation
+  - should be usable just like a conda Cylc installation
   - OK for the central wrapper
   - only local background jobs different (they'll run inside the container)
 - `cylc hub` should be an entry point plugin supplied by the UIS package
@@ -506,7 +506,7 @@ Alpha-2 release
 UIS back compat?
 - OK unless we increment the API version
 - forward compat not possible
-- spawn lastest UIS version by default
+- spawn latest UIS version by default
 - could force auto-shutdown-and-restart (on timeout?) ... maybe not popular
 
 UI datastore

--- a/docs/feb2020-workshop-report.md
+++ b/docs/feb2020-workshop-report.md
@@ -135,7 +135,7 @@ workshop. Now they just need to be implemented or completed.
   - If spawn-on-demand: n-distance window, with n=0 as the scheduler pool
   - (plus option to show whole cycles in SoS or SoD)
 - `cylc review` (Rose Bush) functionality:
-  - contingency: make the old Python 2.7 system compatibile with Cylc 8
+  - contingency: make the old Python 2.7 system compatible with Cylc 8
   - preferably: integrate with the new UI (but must be as convenient to use
       as the old system for historical data)
 - Review User Guide and tutorials for Cylc 8 

--- a/docs/gui-replacement-options.md
+++ b/docs/gui-replacement-options.md
@@ -49,7 +49,7 @@ not work for an in-browser web GUI.
 - __Electron native desktop web apps__
   - chromium browser display engine with node.js wrapper
   - __pros__
-    - architecturally, a straightfoward replacement for current GUIs
+    - architecturally, a straightforward replacement for current GUIs
     - the node.js wrapper could still read the filesystem and scan ports
     - is "web technology"
   - __cons__

--- a/docs/howto/create-a-release.md
+++ b/docs/howto/create-a-release.md
@@ -194,7 +194,7 @@ locally:
    # .../anaconda3/conda-bld/linux-64::cylc-uiserver-0.1-py37_1.
    # This confirms you are installing the local build. Here $PACKAGE_NAME
    # could be something like cylc-uiserver.
-   conda install $PACKAGE_NAME
+   conda install --use-local $PACKAGE_NAME
 ```
 
 At this point you should be good to go. Test the package with commands

--- a/docs/howto/create-a-release.md
+++ b/docs/howto/create-a-release.md
@@ -36,7 +36,7 @@
 - Check locally that you have the updated version of master. Ensure that you
   local copy is up to date, and that it has the correct tags attached.
 - Use `git log` to ensure that you have the correct version and tag.
-- Check that you can buid your distribution locally:
+- Check that you can build your distribution locally:
 
 ```bash
 
@@ -70,7 +70,7 @@
 ## Create a release on Github
 
 - On Github navigate to the repository for which you are creating a release
-  for and click on the relases tab. You should see your tag at the top.
+  for and click on the releases tab. You should see your tag at the top.
 - [Optional] You may wish to open the edit page of a previous release in a
   new tab so that you can copy and paste its data.
 - Click "Draft a new release" button.

--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ Project meetings:
 - March 2020 
   - [Agenda and Notes](meetings/vc-march-2020-agenda.md)
 
-- Februrary 2020 Workshop (see above)
+- February 2020 Workshop (see above)
 
 - 17 December 2019
   - [OS NIWA initial meeting](meetings/dm-os-ho-17Dec2019.md)

--- a/docs/meetings/vc-4-apr-2019-summary.md
+++ b/docs/meetings/vc-4-apr-2019-summary.md
@@ -24,7 +24,7 @@ workflow.
 
 **ACTION: Martin to put WIP code on GitHub and make it available to others** - DONE
 
-Ascyncio in WS: not done yet, but not on the critical path (can be done later).
+Asyncio in WS: not done yet, but not on the critical path (can be done later).
 Oliver has concerns about what it means to put the ZMQ server in the same event
 loop.
 
@@ -44,7 +44,7 @@ New name for server program and repository: "cylc-flow", `cylc-flow.rc` (Sadie)
 with pytest.**
 
 Workflow definition: We decided not to consider supporting YAML any time soon.
-We will have to support parsec/suite.rc for the forseeable future, and the
+We will have to support parsec/suite.rc for the foreseeable future, and the
 future Python API will likely make YAML + templating unnecessary. 
 
 **Next Meeting?** - UK team have limited availability throughout April, and Hilary

--- a/docs/meetings/vc-8-oct-2019-agenda.md
+++ b/docs/meetings/vc-8-oct-2019-agenda.md
@@ -51,7 +51,7 @@ Update on:
 - Cytoscape vs D3 etc
 - prospects for custom node icons etc.
 
-*MR: Cytoscape probably best in most respects, e.g. dynamic graphs and partical
+*MR: Cytoscape probably best in most respects, e.g. dynamic graphs and practical
 updates; "El Grapho" faster?*
 
 *DM and OS: don't forget "cylc graph"; data provision to UI of static graph.*

--- a/docs/meetings/vc-9-aug-2019-summary.md
+++ b/docs/meetings/vc-9-aug-2019-summary.md
@@ -29,7 +29,7 @@ Decision: one-time token per command:
 - then client deletes it when done.
 
 ## UIS - WFS
-- need encrypytion
+- need encryption
 - initial connection is authenticated just like clients (passphrase at the
   moment
 - one-time token will be longer-lived, but that doesn't matter if comms are

--- a/docs/meetings/vc-9-sep-2019-agenda.md
+++ b/docs/meetings/vc-9-sep-2019-agenda.md
@@ -41,8 +41,8 @@ __Packaging and ALPHA-1 RELEASE - 10 min__
   - version naming?
     - need an uber-project name and version number?
 - what do we want to get into the release
-  - a funtioning tree view with job data available - yes?
-  - incremental UIS udpate - no?
+  - a functioning tree view with job data available - yes?
+  - incremental UIS update - no?
   - websocket and subscriptions - no?
 
 

--- a/docs/meetings/vc-9-sep-2019-notes.md
+++ b/docs/meetings/vc-9-sep-2019-notes.md
@@ -19,7 +19,7 @@ __Packaging and ALPHA-1 RELEASE__
 - "full system" alpha-1 release by end of month, needed for Met Office team
   key deliverable
 - Need:
-  - a funtioning tree view with job data available 
+  - a functioning tree view with job data available 
 - Omit from alpha-1?:
   - n-distance window
   - incremental UIS update from WFS
@@ -56,7 +56,7 @@ __cylc-flow.rc__
 - TP: coming along well but not hooked up/functional yet
 
 __Task status naming__
-- HO: do not group "queued" and "ready" into "submitting" as "queueud" is
+- HO: do not group "queued" and "ready" into "submitting" as "queued" is
   important to users (they configure the queues)
 - also: "queued" never fails, but "ready" can in many ways
 - change name "ready" to "preparing"

--- a/docs/meetings/vc-april-2020.md
+++ b/docs/meetings/vc-april-2020.md
@@ -27,7 +27,7 @@ just instituted over much of the world :grimace:)
 - Get it done before the Platforms changes go in
 - How to document use (and meaning of alpha status) for users who install by
   conda?
-  - Cylc web site and Discource 
+  - Cylc web site and Discourse 
 
 ## Spawn on Demand
 
@@ -45,8 +45,8 @@ just instituted over much of the world :grimace:)
 - OS good idea to simplify the test battery by providing a utility to fake the
   DB task pool table to any state, and take the scheduler there directly via
   restart.
-- Some discusionn on a "universal delimiter" for suite/task IDs.  DS's new ID
-  form is good (heirarchy) but can't be used on the command line (the delimiter
+- Some discussion on a "universal delimiter" for suite/task IDs.  DS's new ID
+  form is good (hierarchy) but can't be used on the command line (the delimiter
   is the shell pipe character).  More thought needed.
 - Agreed to get rid of the "task owner" concept in Cylc, used to run jobs on
   other user accounts

--- a/docs/meetings/vc-mar-2019-agenda.md
+++ b/docs/meetings/vc-mar-2019-agenda.md
@@ -107,7 +107,7 @@ Need to resolve disagreement on the model:
 - Do we need to choose coding styles?
    - (only PEP8 so far)
    - Python Docstring Conventions - would be nice to have one that works
-     with most tools (i.e. sphinx, vim syntax hightlight, IDE, napoleon,
+     with most tools (i.e. sphinx, vim syntax highlight, IDE, napoleon,
      etc)
    - Should we use [Black](https://github.com/ambv/black)?
 

--- a/docs/meetings/vc-may-2020.md
+++ b/docs/meetings/vc-may-2020.md
@@ -16,7 +16,7 @@ Cylc-8.0a2
 - Conda Forge ready to go
 - BK's release HowTo (for devs) merged to cylc-admin
 - BK's user instructions merged to cylc-admin
-  - To be posted to the web site and Discource 
+  - To be posted to the web site and Discourse 
 - (Make the release before Platforms changes go in - any day now)
 
 Notes:
@@ -28,7 +28,7 @@ Notes:
 HO
 - Absolute dependence solved and implemented
 - Proposal document finished and comprehensive
-- All unit and funcitonal tests passing on Travis
+- All unit and functional tests passing on Travis
 - PR branch ready for review
    - HO: what remaining details need polishing?
    - Reviewers (OS? DS? others?)

--- a/docs/practices-prompts.md
+++ b/docs/practices-prompts.md
@@ -9,7 +9,7 @@
 _NB. for future thoughts on this general topic:_
 
 - There are many established & tried-and-tested
-  methodologies e.g. flavours of Agile & common tradiational approaches we
+  methodologies e.g. flavours of Agile & common traditional approaches we
   can take inspiration & learn from.
 - We are not tied to any one, therefore free to 'pick-and-choose' practices
   that work well for us.
@@ -22,7 +22,7 @@ _NB. for future thoughts on this general topic:_
 1. How do we assign tasks to a specific team member?
   - We should aim to distribute work/tasks by topic to:
     - minimise silo-ing of knowledge;
-    - accomodate everyone's strengths & weaknesses & preferences;
+    - accommodate everyone's strengths & weaknesses & preferences;
     but...
     - not overwhelm/over-burden anyone, given the range of new technologies
       & theory etc. to learn to use effectively & adapt to.
@@ -36,7 +36,7 @@ _NB. for future thoughts on this general topic:_
     thoroughness, e.g. 'sanity check', 'functionality', 'good enough'
     (where it is not clear exactly what is needed e.g. UI elements)?
   - iii. could we make use of joint e.g. pair reviews to maximise knowledge
-    sharing? Would that consititute one or multiple (e.g. for pairs two)
+    sharing? Would that constitute one or multiple (e.g. for pairs two)
     GitHub reviews?
 
 
@@ -57,7 +57,7 @@ platform freezing & then the Python 2 EOL, so we need to understand if we
 are at least roughly on-track.
 
 2. Retrospectives &/or progress reviews:
-   - i. How often (or upon achievment of what milestones) to have these?
+   - i. How often (or upon achievement of what milestones) to have these?
    - ii. What format should these be in (e.g. discussion or formal document)?
    - iii. How to 'measure' progress?
      - time & effort estimates are notoriously difficult in the software
@@ -155,7 +155,7 @@ Wider team not co-located, & the majority working under towo flipped timezones.
   - Almost round-the-(UTC)-clock development / eyes on the codebase; want
     to leverage this to streamline hand-over for review & testing stages...
   - ...not allow to be a drawback via adding out-of-hours waiting time or via
-    miscommuication.
+    miscommunication.
   - we should also aim to benefit from the different software environments
     e.g. OSs & software stacks at each site for testing purposes.
 
@@ -193,4 +193,4 @@ Critical i.e. operational users must to be able to smoothly change over to
 using the new GUI from the old.
 
 3. Can we provide guidance &/or training in the later stages, before the
-   official vesion release, to (at least) these users?
+   official version release, to (at least) these users?

--- a/docs/proposal-cli-wfs-authentication.md
+++ b/docs/proposal-cli-wfs-authentication.md
@@ -61,7 +61,7 @@ These forms have been distinguished as options:
   token, after a set *time period* is up;
 * **event-based/driven "one-time" tokens**: "single-use" tokens that are
   *created* & *deleted* to cover the duration of set *events*, only being
-  vaild for one such event instance.
+  valid for one such event instance.
 
 
 ### The old (Cylc 7) approach
@@ -98,7 +98,7 @@ least, to change, or which otherwise necessitate changes, as follows:
     the file system is not shared so it is not possible) not use the
     file system;
   * not preclude (later implementation of) fine-grained authorisation for
-    control capacbility, which is not possible with the Cylc 7
+    control capability, which is not possible with the Cylc 7
     authentication model.
 
 
@@ -206,7 +206,7 @@ rest) for the problem outlined in 'The Problem' section above.
   video conference on 08.08.19 (UK date).
 * 19.08.19: amendments made in response to some general feedback by DM & to
   adapt the proposal to the new context & plan relating to overarching
-  WFS security, i.e. also considering the network commuications.
+  WFS security, i.e. also considering the network communications.
 
 
 ### Case-by-case outline

--- a/docs/proposal-platforms.md
+++ b/docs/proposal-platforms.md
@@ -433,9 +433,9 @@ not attempt to address in the initial implementation. These include:
   implemented for selecting the workflow server host.
   * Since we are not running resource intensive commands on these hosts it's not
     clear whether this functionality is really needed?
-  * Note that we can't simply use the existing funtionality for the random host
+  * Note that we can't simply use the existing functionality for the random host
     selection since we need to try each host in turn until the job submission
-    suceeeds (rather than choose a single host to attempt the job submission).
+    succeeds (rather than choose a single host to attempt the job submission).
 
 * If a platform alias has a list of platforms, support other methods for choosing
   which platform to use (rather than just random).

--- a/docs/proposal-state-names.md
+++ b/docs/proposal-state-names.md
@@ -16,7 +16,7 @@ the top we can actually halve the number of abstract task states from 8 to 4.
 | `submit-failed`   | `submit-failed`     | job submitted but did not execute |
 | `running`         | `running`           | job started, but did not finish yet |
 | `succeeded`       | `run-succeeded`     | job finished successfully    |
-| `failed`          | `run-failed`        | job finished unsuccesfully   |
+| `failed`          | `run-failed`        | job finished unsuccessfully   |
 
 Notes:
 - Prefixes `run-` and `submit-` added to disambiguate and make consistent
@@ -64,7 +64,7 @@ Problems:
 
 | NEW name      | meaning                                             |
 |----           | ---                                                 |
-| `waiting`     | (formerly `waiting`, `queued`, and `runahead`) waiting on **all** prequisites |
+| `waiting`     | (formerly `waiting`, `queued`, and `runahead`) waiting on **all** prerequisites |
 | `preparing`   | (formerly `ready`) all prerequisites met; preparing for job submission |
 | `expired`     | (unchanged) waited too long, do not bother to submit    |
 

--- a/docs/release-notes/cylc-8-alpha2.md
+++ b/docs/release-notes/cylc-8-alpha2.md
@@ -23,7 +23,7 @@ improve future releases.
   + [Testing the installation](#testing-the-installation)
   + [Usage](#usage)
 * [Current Limitations](#current-limitations)
-* [What's new](#whats-new)
+* [What's new](#whats-new-since-cylc-80a1)
 
 ## Installation instruction
 
@@ -191,7 +191,7 @@ Cylc-8.0a2 is a preview release with:
 It can run existing Cylc-7 workflows. However:
 - It is not production-ready yet. In production, please use:
   - the latest cylc-7.9 release - with Python 2.7
-  - the lastest cylc-7.8 release - with Python 2.6
+  - the latest cylc-7.8 release - with Python 2.6
 - Do not use it where security is a concern
   - we are still working on Cylc 8 and have not yet fully
     tested or documented its security characteristics

--- a/docs/rose-suite-run-proposal/cylc-flow-rc.md
+++ b/docs/rose-suite-run-proposal/cylc-flow-rc.md
@@ -55,7 +55,7 @@ It is likely that most users will continue to have these set by site admins.
 
 #### 2.2 `[suite run platforms]`
 This is the dictionary key formerly known as ``[suite servers]``. Changed only
-for the purpose of keeping the name "platforms" conistent. This is expected to
+for the purpose of keeping the name "platforms" consistent. This is expected to
 be set only by system administrators. It should include the former top-level
 section `[[suite host self-identification]]`.
 
@@ -132,7 +132,7 @@ The `job platform` to use will be set for a task in the top level of the
 
 #### 3.2 Legacy `[runtime][TASK][job]` & `[runtime][TASK][remote]` behaviour
 
-All the items in `[runtime][TASK][remote]` will be deprecated in favour of equivelent
+All the items in `[runtime][TASK][remote]` will be deprecated in favour of equivalent
 items in a `job platform`. The following items from `[runtime][TASK][job]` will also
 be deprecated in favour of items in `[job platforms]`:
 - `batch system`
@@ -142,7 +142,7 @@ be deprecated in favour of items in `[job platforms]`:
 
 
 `[runtime][TASK][remote]hosts` will be deprecated but we need to ensure that 
-we can handle deprecated useage in a sophisticated way. For back compatibility 
+we can handle deprecated usage in a sophisticated way. For back compatibility 
 if host `host` is a login node defined in `[job platforms]` then that job 
 will use that platform. If a user wishes to over-ride this they can over-ride the
 `[job-platforms][[PLATFORM]]` section.
@@ -155,7 +155,7 @@ strategies:
 3. Raise an error and stop everything dead.
 
 ### 4. Locking down global settings
-There should be a mechanism by which system administators can lock global
+There should be a mechanism by which system administrators can lock global
 settings for their sites. This should probably be a `lock=True/False` switches
 within those settings that we wish to make lockable. If unset these will
 default to `False`. If set to `True` a user who tries to over-ride that setting

--- a/docs/rose-suite-run-proposal/tickets.md
+++ b/docs/rose-suite-run-proposal/tickets.md
@@ -102,7 +102,7 @@ Much the same as the previous but for the database.
 
 The database stores the host and batch_system, we would need to upgrade
 This could be done towards the end, you might need to put off upgrading
-the DB but instead upgrade the information comming out of the database.
+the DB but instead upgrade the information coming out of the database.
 
 This function will need unit testing but will not be wired into cylc as part of
 this ticket.

--- a/docs/spawn-on-submit-history.md
+++ b/docs/spawn-on-submit-history.md
@@ -25,7 +25,7 @@ before they are needed) BUT:
 - Tasks can't run out of cycle-point order
 - The successors of a failed tasks can run (tasks spawn before failing) but
   those of tasks waiting downstream of a failed task can't, which stalls the
-  worklow
+  workflow
 - The task pool has to include at least one cycle-point instance of *every
   task*, and more if there are multiple active cycle points.
  - this is overkill - a lot of tasks are created in the waiting state long

--- a/docs/threats.md
+++ b/docs/threats.md
@@ -61,7 +61,7 @@ Entity-in-the-middle attacks
 
   - no anon access in Cylc 8 (must authenticate)
   - Hub is ignorant of suite state
-  - traffice through hub is HTTPS
+  - traffic through hub is HTTPS
 
 > As an attacker I want to execute my own suite/arbitrary code on HPC
 

--- a/docs/user-research/20190606-suites-guild-cylc-gui-review.md
+++ b/docs/user-research/20190606-suites-guild-cylc-gui-review.md
@@ -18,7 +18,7 @@ These are:
 
 ## Usage of GUIs & GUI vs CLI comments
 #### Table
-| cylc...| All the time | Most Days | Most Weeks | Infreqently | Never|Honestly, I didn't know it existed |
+| cylc...| All the time | Most Days | Most Weeks | Infrequently | Never|Honestly, I didn't know it existed |
 | --- | --- | --- | --- | --- | --- |--|
 |gui (gcylc)|16|4||2|||
 |gscan|8|1| |6|6||
@@ -46,12 +46,12 @@ These are:
 
 ### Usage of Cylc GUI
 #### Are there common gotchas in the cylc guis?
-* [I find it confusing that] task states are ordererd opposite in Gcylc and
+* [I find it confusing that] task states are ordered opposite in Gcylc and
   Gscan
 * Controls that behave unexpectedly
   * All the time on state and name
   * Could it filter differently for different views?
-* Triggering task inheritance sometimes does wierd things
+* Triggering task inheritance sometimes does weird things
 
 #### Are there capabilities in the Cylc GUI's that made your life easier whe you found out about them?
 * Simulation mode
@@ -64,11 +64,11 @@ These are:
 
 #### Do you use task filtering? If you do, what do you use it for?
 
-#### Do you use hierachically named suites?
-* What are hierachically named suites?
+#### Do you use hierarchically named suites?
+* What are hierarchically named suites?
   * Those that know what they are don't use them [at least in this room, if you
     read this on Sharepoint and disagree...].
-  * A user who does use hierachically named suites contacted us later
+  * A user who does use hierarchically named suites contacted us later
     saying that he likes them and would appreciate more controls, 
     both in the GUI and CLI.
 * Not many of us [use them] but seems useful.
@@ -89,10 +89,10 @@ These are:
 ---
 
 ### Appearance & Usability
-#### Do you have issues with GUI perfomance (question implied from answers)?
+#### Do you have issues with GUI performance (question implied from answers)?
 * Slow start up with complex graphs.
 * Occasional gui/gscan dropouts.
-* Suite and/or GUI dissapears
+* Suite and/or GUI disappears
 * Scrolling through large graphs/lists cna be slow/freeze
 * Viewing job log files sometimes fails repeatedly.
 
@@ -138,10 +138,10 @@ These are:
 * --- asked if there would still be a colour blind theme. Was
   told that there would be a colour blind safe theme.
 * Nesting suites are a "monster of jinja2". 👹
-* Would be good to fiter suites by cycle.
+* Would be good to filter suites by cycle.
 * More control of graph view, esp without a mouse 🖱️
 * Can we stagger Alignment of task names in graph view:
-* Can we filter by tasks prequesite to a given task?
+* Can we filter by tasks prerequisite to a given task?
 * Can we focus on tasks < N links from task?
 * Can we have interfaces with other software such as NIWA's Paraview?
   Talk to NIWA contacts to see if this is possible. What about Jupyter

--- a/docs/user-research/MO-user-groups-feedback.md
+++ b/docs/user-research/MO-user-groups-feedback.md
@@ -72,7 +72,7 @@
   sure users are informed of any deprecations.]
 
 * RR: A new UI is good, but I actually prefer the command line, e.g. because
-  I can explicitly see & use the whole "plehtora of options". Will I still
+  I can explicitly see & use the whole "plethora of options". Will I still
   be able to interact with my suites purely by command, as I can do now? [We
   said yes, but stressed that we are not neglecting the CLI for the new UI,
   in fact we have plans including a wide-ranging "CLI refactor" Issue
@@ -101,7 +101,7 @@
 * MB: Will you still be able to have multiple instances open, like multiple
   windows for the old GUIs? I guess it would be multiple tabs now? [We
   confirmed that multiple tabs would be the browser equivalent, & that the UI
-  will work across mutliple tabs, but explained how we are trying to reduce
+  will work across multiple tabs, but explained how we are trying to reduce
   the need for multiple (and especially large numbers of) tabs with the
   multi-view panelling system, which aims to show users as much information
   as they could want to see, all within a single tab.
@@ -211,7 +211,7 @@ non-UI Cylc matter (which is of relevance to future Python API work):
   to the right audience, else it would be too specialised or simplistic. [We
   said we agree.]
 * ??: It could also be helpful to include answers to frequently asked
-  questions (FAQs) via a dedicated page or in a sutiable component. [We said
+  questions (FAQs) via a dedicated page or in a suitable component. [We said
   we thought that was a good idea, & we would consider it, though that
   something of that nature might be better placed in the documentation.]
 

--- a/docs/user-research/ur-initiation-questions.md
+++ b/docs/user-research/ur-initiation-questions.md
@@ -97,7 +97,7 @@ Shorthands used throughout:
   [bias by inclination & availability](https://measuringu.com/random-sample/)).
 * Users cannot join in with something they are not aware of, so *advertising*
   for UR participation is crucial.
-* We cannot, like specialised UX or private firms etc, offer renumeration
+* We cannot, like specialised UX or private firms etc, offer remuneration
   for feedback, but that is not to say we cannot be creative to offer
   *non-monetary* incentives.
 
@@ -270,7 +270,7 @@ Shorthands used throughout:
   taken from their day-to-day work on their laptop, as shared on the screens,
   & describing some brief background & how they use C&R to go about solving it.
 * As well as the above, invite & encourage *random pieces of user feedback*,
-  via the usual channels but also by setting up & advertisting a form for that
+  via the usual channels but also by setting up & advertising a form for that
   purpose only. Users may think of something important to convey during their
   day-to-day work, & this would allow them to note it down easily at the
   time, where it otherwise may be forgotten.
@@ -284,13 +284,13 @@ Shorthands used throughout:
   including information that could be very useful.
 * However, the context in which it was said is really important. For example,
   a user might have conveyed a more negative opinion than they really hold
-  at a stressful instance (a deadline or when encourntering a bug) or have
+  at a stressful instance (a deadline or when encountering a bug) or have
   made a comment about an aspect of C &/ R that has since been
   modified so that it is no longer applicable.
 
 #### My proposals:
 
-* Consider signifcant past feedback only where it is evidenced visibly,
+* Consider significant past feedback only where it is evidenced visibly,
   (typically in writing) & not just recalled from someone's memory, & only
   where there is enough background evidenced to provide context to record.
 * To uncover & expose useful feedback conveyed in the past in this way,

--- a/docs/user-research/ur-meetings/ur-04-june-2019-summary.md
+++ b/docs/user-research/ur-meetings/ur-04-june-2019-summary.md
@@ -62,7 +62,7 @@ After discussion on how to best record UR findings, agree to:
    * MS asked whether there could be sensitive information to take care with
      sharing given that the information will be openly-viewable on GitHub. From
      that agreed to use initials for individual user names, & remember or record
-     in personal notes who they refer to for potential clashes in intials.
+     in personal notes who they refer to for potential clashes in initials.
 10) Agreed there should be two main UR records in the GitHub repo:
     * document(s) summarising each user interaction/meeting, &;
     * a document containing the overall "pool" of data and insights. 


### PR DESCRIPTION
Remembered that when reading the Conda notes this morning, didn't find the `--use-local` in the docs.

Reading the release notes in our site, noted that one markdown link (what's new) was broken.

And the IDE found some typos, so just applied its suggestions.

:+1: nothing critical here, doesn't need to be reviewed or merged before our release.