### PR TITLE
add instruction for testing the docs

### DIFF
--- a/docs/howto/create-a-release.md
+++ b/docs/howto/create-a-release.md
@@ -53,6 +53,19 @@
    rm -r dist
 ```
 
+## Test the docs
+
+For any projects which are auto-documented by cylc-doc, currently:
+
+* cylc-flow
+
+Ensure the docs build against master by manually triggering the test workflow
+in cylc-doc.
+
+This will catch syntax errors, broken urls etc which need to be fixed
+prior to releasing the project.
+
+
 ## Tag the version
 
 ```bash


### PR DESCRIPTION
Because cylc-doc autodocuments other projects it is necessary to test that the docs build correctly before releasing any of these documented projects. Otherwise we will have to re-release in order to fix little things like broken urls.

These breakages should get picked up by our nightly testing (when we get that off the ground), however, this is a quick simple check which should be worthwhile.