### PR TITLE
Riot is now Element

### DIFF
--- a/docs/howto/create-a-release.md
+++ b/docs/howto/create-a-release.md
@@ -274,6 +274,6 @@ Plus, we also give it a pattern to the build string, so conda will match
 `cylc-flow-8.0a2-py37_2`, or ``cylc-flow-8.0a2-py38_2`, or
 `cylc-flow-8.0a2-py37h2387c_2` (all valid build strings).
 
-## Announce on Riot and Discourse?
+## Announce on Element and Discourse?
 
 Bask in the glory of having created a release.

--- a/docs/project-collab.md
+++ b/docs/project-collab.md
@@ -1,7 +1,7 @@
 # Project Communication and Collaboration
 
-**Riot.im:** various chat rooms under the
-  [cylc organisation](https://riot.im/app/#/group/+cylc:matrix.org).
+**Element:** various chat rooms under the
+  [cylc organisation](https://app.element.io/#/group/+cylc:matrix.org).
 - day-to-day chat (group and ad hoc one-to-one Rooms) for figuring stuff out,
   too dynamic and too much detail for GitHub Issues
 - group video conference and ad hoc video chat.
@@ -9,22 +9,20 @@
 **Trello:** project board(s) under
   ["The Cylc Workflow Engine" Team](https://trello.com/cylcworkflow).
 - for keeping track of topics, and recording related conclusions and decisions
-  reached on Riot.
+  reached on Element.
 - Trello card decks should eventually resolve to multiple GitHub Issues
 - Deck names should be pretty broad, with specific cards for sub-topics.
 
 **GitHub Issues**: [cylc](https://github.com/cylc)
 - describe implementation of single well-defined topics that eventually result
   in single (or few) Pull Requests
-- (detail should be discussed on Riot, and big overarching Issues can be
+- (detail should be discussed on Element, and big overarching Issues can be
   tracked on Trello)
 
 **Cylc Admin:** (THIS SITE)
 - summary documents to explain our strategy to others
 - and to track the project globally (Gantt chart etc.)
 
-**Google Groups:** [Cylc Forum](https://groups.google.com/forum/#!forum/cylc) 
+**Discourse:** [Cylc Forum](https://cylc.discourse.group/)
 - release announcements, plus usage questions, feature requests, and bug
   reports from remote users (outside of the main sites).
-- **DEPRECATED** pending a move to **Cylc Discourse Forum** (hope to bring
-  main-site users in here too).


### PR DESCRIPTION
Going through my notes taken during our latest release. In one release doc we had Riot I think, so tried to replace the occurrences that were not meeting minutes (no point in update those I think) and update Riot -> Element.

Also replaced Google Groups by Discourse in the collab document. One review should do.