### PR TITLE
SoD proposal/doc update.

### DIFF
--- a/docs/proposal-spawn-on-d.md
+++ b/docs/proposal-spawn-on-d.md
@@ -216,8 +216,8 @@ spawn an infinite number of children (`bar.1,2,3,...`), which obviously is not
 feasible.
 
 (Note without the first line above `start` is not defined on any sequence, so
-with SoS the scheduler will stall with `foo` unsatisfied, but with SoD it will
-shut down immediately with nothing to do because and `foo` never gets spawned.)
+with SoS the scheduler will stall with `bar` unsatisfied, but with SoD it will
+shut down immediately with nothing to do because and `bar` never gets spawned.)
 
 Worse, `bar` could also have other non-absolute triggers, and it could be
 those that spawn initial instances of `bar` before `start` is finished:

--- a/docs/proposal-spawn-on-d.md
+++ b/docs/proposal-spawn-on-d.md
@@ -732,6 +732,9 @@ Follow-up changes needed in `cylc/cylc-flow`:
   have absolute triggers (auto-spawning them all isn't really a problem, but it
   is less "on demand" than it could be).
 
+- Change to event-driven triggering (easy: see TODO at the end of
+  task_pool:spawn_on_ouput)
+
 - Consider re-instating (most of?) the pre-SoD `cylc insert` functional tests
   as `cylc trigger` tests.
 

--- a/docs/proposal-spawn-on-d.md
+++ b/docs/proposal-spawn-on-d.md
@@ -217,7 +217,7 @@ feasible.
 
 (Note without the first line above `start` is not defined on any sequence, so
 with SoS the scheduler will stall with `bar` unsatisfied, but with SoD it will
-shut down immediately with nothing to do because and `bar` never gets spawned.)
+shut down immediately with nothing to do because `bar` never gets spawned.)
 
 Worse, `bar` could also have other non-absolute triggers, and it could be
 those that spawn initial instances of `bar` before `start` is finished:
@@ -252,13 +252,15 @@ tasks with no non-absolute triggers to spawn them on demand).
 #### Retriggering
 
 Retriggering a finished absolute parent (with `--reflow`) will cause it to
-respawn its first child, then subsequent children as normal - that's what the
-graph says. But we may want to provide an option to change the first child
-spawned to a current cycle rather than going back to the start (use case:
+respawn its first child, and then spawn subsequent children as normal (spawn
+next instance on release from the runahead pool as described above)  - that's
+what the graph says. But we may want to provide an option to change the first
+child spawned to a current cycle rather than going back to the start (use case:
 retrigger a start-up task that rebuilds a model or whatever, but don't re-run
 old cycles). Alternatively, simply retrigger the absolute parent without
-reflow, then retrigger with reflow the first child that you want to continue
-from.
+reflow (this will run only the parent), then retrigger with reflow the first
+child that you want to continue from (this will trigger the targeted child,
+and that will spawn the next instance on release from the runahead pool, etc.).
 
 ### Failed task handling
 

--- a/docs/proposal-spawn-on-d.md
+++ b/docs/proposal-spawn-on-d.md
@@ -232,7 +232,7 @@ before `start.2` is done. This suggests we might need to do repeated checking
 of unsatisfied absolute triggers until they become satisfied. However, it turns
 out that's not necessary...
 
-#### Implementation:
+#### Absolute trigger implementation:
 
 1. Whenever an absolute output (e.g. `start.2:succeed` above) is completed the
 scheduler should:
@@ -316,7 +316,7 @@ to xtrigger outputs).
 We will keep suicide triggers for backward compatibility, and in case they are
 still useful for rare edge cases like this.
 
-#### Implementation
+#### Suicide trigger implementation
 
 Suicide triggers are just like normal triggers except for what happens once
 they are satisfied (i.e. the task gets removed instead of submitting). In
@@ -725,8 +725,8 @@ graphically the consequences of their intended reflow).
 Follow-up changes needed in `cylc/cylc-flow`:
 
 - Consider the clarity and usefulness of all SoD log messages. Messages about
-[not spawning suicide-triggered tasks](#back-compat-implementation) have been
-noted as confusing. Move most to DEBUG level?
+  [not spawning suicide-triggered tasks](#suicide-trigger-implementation) have
+  been noted as confusing. Move most to DEBUG level?
 
 - Don't auto-spawn all tasks with an absolute trigger, just those that *only*
   have absolute triggers (auto-spawning them all isn't really a problem, but it


### PR DESCRIPTION
Two new commits.
- The first commit documents exactly how suicide triggers work under SoD (after an email from @dpmatthews)
- The second commit documents the new handling of absolute triggers (after SoD review comments from @dwsutherland)

Both add minor items to the TODO list, to be converted to issues after the SoD PR is merged.