### PR TITLE
fix typo

### DIFF
--- a/docs/proposal-rose-suite-run.md
+++ b/docs/proposal-rose-suite-run.md
@@ -265,8 +265,8 @@ Proposed contents of the `log` directory in the run directory.
 * `db` - no change
 * `job/` - no change
 * `scheduler/` - replaces `suite/`
-* `conf/` - replaces `suiterc/` and `rose-conf/*.conf`
+* `conf/` - replaces `suiterc/` and `rose-conf/*.conf` (contains Cylc + Rose confs)
   * see also [cylc-flow #3763](https://github.com/cylc/cylc-flow/issues/3763)
-* `install/<timestamp>-install.log` (replaces `rose-suite-run.log`)
-* `install/<timestamp>-reload.log` (currently appended to `rose-suite-run.log`)
-* `install/<timestamp>-vc.log` (replaces rose-conf/*.version)
+* `-install/` - installation logs
+  * `install/<timestamp>-install.log` (replaces `rose-suite-run.log`)
+  * `install/<timestamp>-vc.log` (replaces rose-conf/*.version)


### PR DESCRIPTION
The proposal suggested we would have an `install/reload.log`, I think this should have said `reinstall` as install and reload are orthogonal.

Suggest just calling the file `install` since the `re-` is superfluous.