### PR TITLE
new release: add instruction to update changes page in cylc-doc

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-release.md
+++ b/.github/ISSUE_TEMPLATE/new-release.md
@@ -19,6 +19,7 @@ See [the release docs](https://github.com/cylc/cylc-admin/blob/master/docs/howto
 
 * [ ] The release lead should be assigned to this issue.
 * [ ] Ensure all milestones complete.
+* [ ] Ensure major changes are listed in cylc-doc (`reference/changes`).
 * [ ] Test cylc-doc (run a test build, perform any required fixes).
 * [ ] Run cylc-flow functional tests against locally available platforms.
 * [ ] List the milestones for release below (delete entries as appropriate).


### PR DESCRIPTION
To accompany https://github.com/cylc/cylc-doc/pull/510