### PR TITLE
add status page

### DIFF
--- a/.github/wokflows/status.yml
+++ b/.github/wokflows/status.yml
@@ -37,10 +37,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: configure python
         uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
 
       - name: install
         run: pip install jinja2

--- a/.github/wokflows/status.yml
+++ b/.github/wokflows/status.yml
@@ -1,0 +1,61 @@
+# THIS FILE IS PART OF THE CYLC WORKFLOW ENGINE.
+# Copyright (C) NIWA & British Crown (Met Office) & Contributors.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Deploy a new version of the documentation or rebuild an existing one.
+
+# Note: This action deletes its previous commits so the nightly build history
+# is not preserved and does not require housekeeping.
+
+name: Status
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '35 0 * * *'
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'docs/status/*'
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: configure python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: install
+        run: pip install jinja2
+
+      - name: update
+        working-directory: docs/status
+        run: python build branches.json template.md.jinja2 status.md
+
+      - name: configure git
+        uses: cylc/release-actions/configure-git@v1
+
+      - name: push changes
+        working-directory: gh-pages
+        run: |
+          git status
+          git add docs/status/status.md
+          git commit -m '-nightly build-'
+          git push origin master

--- a/.github/wokflows/status.yml
+++ b/.github/wokflows/status.yml
@@ -14,10 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Deploy a new version of the documentation or rebuild an existing one.
-
-# Note: This action deletes its previous commits so the nightly build history
-# is not preserved and does not require housekeeping.
 
 name: Status
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# derived files
+docs/status/status.md
+
+# python bytecode
+*.py[cod]
+__pycache__/
+
+# vim backup files
+*.swp
+
+# emacs backup files
+*~
+
+# vscode
+.vscode
+
+# mypy
+.mypy_cache/
+
+# docker stuffs
+.docker*
+
+# operating system junk
+.DS_Store

--- a/docs/status/branches.json
+++ b/docs/status/branches.json
@@ -1,0 +1,28 @@
+{
+    "meta_releases": {
+        "8.0.x": {
+            "cylc/cylc-flow": "8.0.x",
+            "cylc/cylc-doc": "8.0.x",
+            "cylc/cylc-rose": "1.1.x",
+            "cylc/cylc-uiserver": "1.1.x",
+            "metomi/rose": "2.0.x"
+        },
+        "8.1.x": {
+            "cylc/cylc-flow": "master",
+            "cylc/cylc-doc": "master",
+            "cylc/cylc-rose": "master",
+            "cylc/cylc-uiserver": "master",
+            "metomi/rose": "master"
+        }
+    },
+    "branch_actions": {
+        "cylc/cylc-flow": ["test_fast", "test_functional", "build"],
+        "cylc/cylc-rose": ["tests"],
+        "cylc/cylc-uiserver": ["test", "build"],
+        "cylc/cylc-doc": ["test"],
+        "metomi/rose": ["test"]
+    },
+    "nightly_actions": {
+        "cylc/cylc-doc": ["nightly"]
+    }
+}

--- a/docs/status/branches.json
+++ b/docs/status/branches.json
@@ -1,13 +1,13 @@
 {
     "meta_releases": {
-        "8.0.x": {
-            "cylc/cylc-flow": "8.0.x",
-            "cylc/cylc-doc": "8.0.x",
+        "8.1": {
+            "cylc/cylc-flow": "8.1.x",
+            "cylc/cylc-doc": "8.1.x",
             "cylc/cylc-rose": "1.1.x",
             "cylc/cylc-uiserver": "1.1.x",
             "metomi/rose": "2.0.x"
         },
-        "8.1.x": {
+        "8.2": {
             "cylc/cylc-flow": "master",
             "cylc/cylc-doc": "master",
             "cylc/cylc-rose": "master",

--- a/docs/status/build
+++ b/docs/status/build
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+from pathlib import Path
+
+from jinja2 import (
+    Environment,
+    StrictUndefined,
+    FileSystemLoader,
+)
+
+
+def render(data_file, template_file, output_file):
+    with open(template_file, 'r') as template_fh:
+        template_code = template_fh.read()
+
+    with open(data_file, 'r') as data_fh:
+        data = json.load(data_fh)
+
+    kwargs = {
+        'loader': FileSystemLoader([Path(template_file).parent]),
+        'undefined': StrictUndefined,
+    }
+    env = Environment(**kwargs).from_string(template_code)
+
+    with open(output_file, 'w') as output_fh:
+        output_fh.write(
+            env.render(data)
+        )
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('data')
+    parser.add_argument('template')
+    parser.add_argument('output')
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    render(args.data, args.template, args.output)

--- a/docs/status/template.md.jinja2
+++ b/docs/status/template.md.jinja2
@@ -1,3 +1,12 @@
+{#
+
+This template/markdown file is auto-generated, please do not edit it directly.
+
+Please edit `branches.json` and raise a pull request, this fille will be
+automatically regenerated on merge.
+
+#}
+
 {% macro badge(repo, branch, action) -%}
 [![{{ action }}](https://github.com/{{ repo }}/actions/workflows/{{ action }}.yml/badge.svg?branch={{ branch }})](https://github.com/{{ repo }}/actions/workflows/{{ action }}.yml)
 {%- endmacro %}

--- a/docs/status/template.md.jinja2
+++ b/docs/status/template.md.jinja2
@@ -1,0 +1,39 @@
+{% macro badge(repo, branch, action) -%}
+[![{{ action }}](https://github.com/{{ repo }}/actions/workflows/{{ action }}.yml/badge.svg?branch={{ branch }})](https://github.com/{{ repo }}/actions/workflows/{{ action }}.yml)
+{%- endmacro %}
+
+{% macro format_repo(repo) -%}
+[**{{ repo }}**](https://github.com/{{ repo }})
+{%- endmacro %}
+
+{% macro format_branch(repo, branch) -%}
+[{{ branch }}](https://github.com/{{ repo }}/tree/{{ branch }})
+{%- endmacro %}
+
+{%- macro format_actions(repo, branch, actions) -%}
+  {%- for action in actions -%}
+    {{ badge(repo, branch, action) }}
+    {%- if not loop.last %} {% endif -%}
+  {%- endfor -%}
+{%- endmacro -%}
+
+# Status {{ badge('cylc/cylc-admin', 'master', 'status') }}
+
+## Nightly Builds
+
+| repo | actions |
+|:---|:---|
+{% for repo, actions in nightly_actions.items() -%}
+| {{ format_repo(repo) }} | {{ format_actions(repo, 'master', actions) }} |
+{%- endfor %}
+
+## Branches
+
+{% for meta_release, components in meta_releases.items() %}
+### {{ meta_release }}
+| repo | branch | actions |
+|:---|:---|:---|
+{% for repo, branch in components.items() -%}
+| {{ format_repo(repo) }} | {{ format_branch(repo, branch) }} | {{ format_actions(repo, branch, branch_actions.get(repo, [])) }} |
+{% endfor %}
+{% endfor %}


### PR DESCRIPTION
* Add a JSON file mapping component branches to meta releases.
  This will save us having to maintain this list for each of the components individually.
* Add a status page generated from this to give better visibility of failures.

This can be used to automatically pick compatible Cylc versions for installation for CI in the Cylc component repositories via release-actions - https://github.com/cylc/release-actions/pull/46

![Screenshot from 2023-02-03 13-24-10](https://user-images.githubusercontent.com/16705946/216614296-1c8ec8fd-fb2f-4f43-8759-89bbf4c8bc23.png)