### PR TITLE
Update branches.json

### DIFF
--- a/docs/status/branches.json
+++ b/docs/status/branches.json
@@ -4,6 +4,13 @@
             "cylc/cylc-flow": "8.2.x",
             "cylc/cylc-doc": "8.2.x",
             "cylc/cylc-rose": "1.3.x",
+            "cylc/cylc-uiserver": "master",
+            "metomi/rose": "2.1.x"
+        },
+        "8.2-jps-v1": {
+            "cylc/cylc-flow": "8.2.x",
+            "cylc/cylc-doc": "8.2.x",
+            "cylc/cylc-rose": "1.3.x",
             "cylc/cylc-uiserver": "1.3.x",
             "metomi/rose": "2.1.x"
         },


### PR DESCRIPTION
I think this should work fine because `json.load` appears to preserve key order and the CI will pick the first matching item:

https://github.com/cylc/release-actions/blob/v1/bin/pick_compatible_branches#L33