### PR TITLE
status: add milestone and issue badges

### DIFF
--- a/docs/status/branches.json
+++ b/docs/status/branches.json
@@ -1,4 +1,20 @@
 {
+    "repos": [
+        "cylc/cylc-flow",
+        "cylc/cylc-doc",
+        "cylc/cylc-rose",
+        "cylc/cylc-uiserver",
+        "metomi/rose",
+        "cylc/cylc-admin",
+        "cylc/cylc.github.io",
+        "cylc/cylc-sphinx-extensions",
+        "cylc/release-actions",
+        "cylc/cylc-textmate-grammar",
+        "cylc/Cylc.tmbundle",
+        "cylc/vscode-cylc",
+        "cylc/language-cylc",
+        "cylc/cylc.vim"
+    ],
     "meta_releases": {
         "8.2": {
             "cylc/cylc-flow": "8.2.x",

--- a/docs/status/build
+++ b/docs/status/build
@@ -1,14 +1,51 @@
 #!/usr/bin/env python
 
+"""Build the status page.
+
+To test manually, you'll need to set up a "personal access token" with
+read permissions. On CI we use `GITHUB_TOKEN`.
+
+Usage:
+  $ export GITHUB_TOKEN=<token>
+  $ python build branches.json template.md.jinja2 status.md
+  # then open the status.md file in a markdown viewer or convert to html e.g:
+  $ npm install marked
+  $ marked status.md -o status.html
+
+"""
+
 import argparse
 import json
+import os
 from pathlib import Path
+import urllib.request
 
 from jinja2 import (
     Environment,
     StrictUndefined,
     FileSystemLoader,
 )
+
+
+def list_milestones(repo, per_page=100):
+    _org, _repo = repo.split('/')
+    url = (
+        'https://api.github.com/repos/'
+        f'{_org}/{_repo}/milestones?per_page={per_page}'
+    )
+    print(f'# {url}')
+    req = urllib.request.Request(
+        url,
+        headers={
+            'Authorization': f'Bearer {os.environ["GITHUB_TOKEN"]}',
+        },
+    )
+    with urllib.request.urlopen(req) as f:
+        milestones = json.loads(f.read().decode('utf-8'))
+        return sorted(
+            (milestone['title'], milestone['number'])
+            for milestone in milestones
+        )
 
 
 def render(data_file, template_file, output_file):
@@ -22,8 +59,10 @@ def render(data_file, template_file, output_file):
         'loader': FileSystemLoader([Path(template_file).parent]),
         'undefined': StrictUndefined,
     }
-    env = Environment(**kwargs).from_string(template_code)
+    env = Environment(**kwargs)
+    env.globals['list_milestones'] = list_milestones
 
+    template = env.from_string(template_code)
     with open(output_file, 'w') as output_fh:
         output_fh.write(
             "<!-- This file is auto-generated, please do not edit it directly."
@@ -32,7 +71,7 @@ def render(data_file, template_file, output_file):
             "will be automatically regenerated on merge. -->\n"
         )
         output_fh.write(
-            env.render(data)
+            template.render(data)
         )
 
 

--- a/docs/status/template.md.jinja2
+++ b/docs/status/template.md.jinja2
@@ -1,6 +1,36 @@
-{% macro badge(repo, branch, workflow) -%}
+{% macro workflow_badge(repo, branch, workflow) -%}
 <a href="https://github.com/{{ repo }}/actions/workflows/{{ workflow }}.yml?query=branch%3A{{ branch }}">
   <img src="https://github.com/{{ repo }}/actions/workflows/{{ workflow }}.yml/badge.svg?branch={{ branch }}" />
+</a>
+{%- endmacro %}
+
+{% macro milestone_badge(repo, number, open=True) -%}
+<a href="https://github.com/{{ repo }}/milestone/{{ number }}?q=is%3A{{ "open" if open else "closed" }}">
+  <img src="https://img.shields.io/github/milestones/issues-{{ "open" if open else "closed" }}/{{ repo }}/{{ number }}" />
+</a>
+{%- endmacro %}
+
+{% macro no_milestone_badge(repo) -%}
+<a href="https://github.com/{{ repo }}/issues?q=is%3Aopen+no%3Amilestone">
+  <img src="https://img.shields.io/github/issues-search/{{ repo }}?query=is%3Aopen%20no%3Amilestone&label=no%20milestone" />
+</a>
+{%- endmacro %}
+
+{% macro issue_badge(repo) -%}
+<a href="https://github.com/{{ repo }}/issues/?q=is%3Aopen+is%3Aissue">
+  <img src="https://img.shields.io/github/issues-raw/{{ repo }}" />
+</a>
+{%- endmacro %}
+
+{% macro issues_by_label_badge(repo, label) -%}
+<a href="https://github.com/{{ repo }}/issues?q=is%3Aissue+is%3Aopen+label%3A{{ label }}">
+  <img src="https://img.shields.io/github/issues/{{ repo }}/{{ label }}" />
+</a>
+{%- endmacro %}
+
+{% macro prs_badge(repo) -%}
+<a href="https://github.com/{{ repo }}/pulls">
+  <img src="https://img.shields.io/github/issues-pr/{{ repo }}" />
 </a>
 {%- endmacro %}
 
@@ -18,12 +48,14 @@
 
 {%- macro format_status(repo, branch, workflows) -%}
   {%- for workflow in workflows -%}
-    {{ badge(repo, branch, workflow) }}
+    {{ workflow_badge(repo, branch, workflow) }}
     {%- if not loop.last %} {% endif -%}
   {%- endfor -%}
 {%- endmacro -%}
 
-# Status {{ badge('cylc/cylc-admin', 'master', 'status') }}
+# Status
+
+{{ workflow_badge('cylc/cylc-admin', 'master', 'status') }}
 
 ## Nightly Builds
 
@@ -59,4 +91,22 @@
   </tr>
 {%- endfor %}
 </table>
+{% endfor %}
+
+## Issues
+
+{% for repo in repos %}
+### {{ repo }}
+
+{{ issue_badge(repo) }} {{ prs_badge(repo) }} {{ issues_by_label_badge(repo, 'question') }} {{ issues_by_label_badge(repo, 'bug') }} {{ no_milestone_badge(repo) }}
+
+<table style="margin-left:20px; margin-top:10px">
+{% for milestone, number in list_milestones(repo) %}
+<tr>
+  <td>{{ milestone_badge(repo, number) }}</td>
+  <td>{{ milestone_badge(repo, number, open=False) }}</td>
+</tr>
+{% endfor %}
+</table>
+
 {% endfor %}


### PR DESCRIPTION
Auto generate the content on this page: https://cylc.github.io/cylc-admin/project-issue-summary.html

And append it to the end of the status page.

* List open/closed issues for all open milestones.
* List number of issues/PRs/questions etc for each repo.