### PR TITLE
proposal set: fix small error

### DIFF
--- a/docs/proposal-cylc-set.md
+++ b/docs/proposal-cylc-set.md
@@ -72,7 +72,8 @@ By default this sets all required outputs for the given task(s).
    --pre=PRE: Set a prerequisite to satisfied e.g. `foo:succeeded`
               (multiple use allowed, may be comma separated).
 
-   --pre=all: Set all prerequisites to satisfied. Equivalent to trigger.
+   --pre=all: Set all prerequisites to satisfied. Equivalent to adding the task
+              into the workflow in the waiting state.
 
    --out=OUT: Set an output e.g. `succeeded` (and implied outputs) to completed
               (multiple use allowed, may be comma separated).


### PR DESCRIPTION
Sorry, spotted a small error in the `cylc set` proposal.

`cylc set --pre=all` is NOT equivalent to trigger as outlined in "[7. Spawning parentless tasks](https://github.com/cylc/cylc-admin/blob/master/docs/proposal-cylc-set.md#7-spawning-parentless-tasks)". It's more equivalent to Cylc 7's insert.