### PR TITLE
fix status page

### DIFF
--- a/.github/workflows/status.yml
+++ b/.github/workflows/status.yml
@@ -33,6 +33,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Workflow failed because we need to explicitly provide GITHUB_TOKEN as an environment variable.