### PR TITLE
amendment to proposal amendment

### DIFF
--- a/docs/proposal-optional-output-extension.md
+++ b/docs/proposal-optional-output-extension.md
@@ -41,16 +41,33 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
    executed and that might not happen if expiry or submission are optional (or if the pre-requisites
    for `a` are not met).
 
-3. A task is incomplete if the completion condition is not satisfied and:
+3. A task is complete if the completion condition is satisfied.
 
-   * It finished executing
+   The completion condition can be defined by the user, otherwise the
+   expression is automatically generated according to the rules:
 
-   * OR Job submission failed and the `:submit` output was not optional
+   1. All required outputs (referenced in the graph) must be satisfied.
+   2. If success is optional, then the task is complete if it fails.
+   3. If submission is optional, then the task is complete if it submit-fails.
+   4. If expiry is optional, then the task is complete if it expires.
 
-   * OR The task expired and the `:expire` output was not optional
-     * This is a new condition to handle expiry
+   I.E:
+
+   ```python
+   is_complete = (
+     all(output for output in outputs if not is_optional(output))
+     or (failed if is_optional(succeeded))
+     or (submit_failed if is_optional(submitted))
+     or (expired if is_optional(expired))
+   )
+   ```
+
+   Note, a task is *in*complete, if the completion condition is not satisfied
+   but the task has a final task status (note status not output). This is the
+   same as presently implemented (8.2.x)
 
 4. `:expire` cannot be required.
+
    Similarly `:submit-fail` cannot be required.
    
    * We currently allow `:submit-fail` to be required but this doesn't really make sense.
@@ -69,6 +86,8 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
    # OK
    completion = succeeded or failed
    completion = succeeded and (x or y or z)
+   completion = (succeeded and x) or (failed and y)
+   completion = (succeeded and (x or y or z)) or failed or expired
 
    # ERROR
    completion = not failed
@@ -78,8 +97,8 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
 
    Expression to be validated (i.e. parsed) at validate time.
 
-   If the completion expression is defined, any outputs which are optional in the expression
-   should be marked as optional in the graph if used in the graph:
+   If the completion expression is user-defined, then it must be logically
+   consistent with the graph.
 
    ```
    completion(a) = succeeded and (x or y or z)
@@ -114,40 +133,36 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
    }
    ```
 
-   Note: the completion condition only covers outputs generated when a task is executed - it cannot
-   include `:expired`, `:submit` or `:submit-fail`. It also cannot include `started` (this has to
-   happen if a task executes) or `finished` (this isn't an output).
+   The completion expression cannot include `finished` (this isn't an output).
 
-   The default condition is complete all required outputs.
+6. Expiry is only optional if it is explicitly referenced in the graph (e.g.
+   `a:expired? => x`) or permitted in the completion expression
+   (e.g. `succeeded or expired`).
 
-6. Expiry is only optional if it is explicitly referenced in the graph e.g. `a:expired? => x`.
-
-   If a task is configured to clock-expire it must be made optional via the graph - otherwise this
-   will cause a validation failure. This is designed to reduce the risk of unintended early shutdown.
-
-   For this example:
+   E.G. in these examples:
 
    ```
-   clock-expire = a
-   a => b
-   a:expired?  # This does nothing but is sufficient to pass validation
-   b:submit-fail? => c
+   a => z
+
+   b => z
+   b:expired?
+
+   c
+   # completion = succeeded or expired
    ```
 
-   Task "a" is completed in one of 2 ways:
+   If the `expired` output is set on both tasks `a` and `b`:
 
-   * It expires
-   * It executes and succeeds
+   * `a` will be incomplete.
+   * `b` will be complete (permitted in graph).
+   * `c` will be complete (permitted in completion expression).
 
-   If task "a" succeeds then task "b" must complete which can happen in one of 2 ways:
-
-   * It fails to submit
-   * It executes and succeeds
-
-   So, the expression `a => b` in the graph can be interpreted as:
-   * If "a" executes it must succeed
-   * If "a" succeeds then "b" must complete
-   * If "b" executes it must succeed
+   If a task is configured to clock-expire, but expiry is not handled in the
+   graph or permitted in the completion expression, a warning should be raised
+   informing the user that the workflow may stall. The warning should
+   recommend that they either handle the expired output in the graph if no
+   completion expression is defined, or permit it in the completion expression
+   if one is defined.
 
 7. If neither `:succeed` nor `:fail` are specified for a task in the graph then `:succeed` should
    be required.
@@ -253,7 +268,7 @@ a => x
 a:expired?
 ```
 
-`a:expired?` has to be included in the graph to avoid validation failure.
+`a:expired?` has to be included in the graph to avoid stall.
 This makes it clear that the halt is intentional.
 
 ### Output Groups


### PR DESCRIPTION
### Summary

* Redefine task "incompletion" to avoid problem edge cases.
* Permit pre-conditions in completion expressions (no longer any reason not to, this makes things clearer for users)
* Remove redundant safety check that was only required for the previous proposal

### *In*completion condition bugs

Closer inspection of the condition for task "incompletion" revealed some logical flaws, e.g:

#### 1. Task cannot be completed by the expired output.

If a task is expired (and expiry is permitted) then it is complete, but subsequently setting a finished output would make it incomplete by satisfying the "it finished executing" condition.

Similarly, if the task succeeds, fails or submit-fails, then it will not be possible to subsequently complete it by setting the expired output.

#### 2. Tasks with no required outputs

It is possible for a task to have no required outputs, e.g:

```
a:submitted?
a:succeeded?
a:expired?
```

In this case the completion condition is `True`. By the previous logic the task is complete before it has even been submitted.

#### Underlying issue

These flaws weren't intentional, they are just bugs. The issue here is the defining *in*completion which results in a lot of double negatives.

For the same reason we cannot use `not` in completion conditions (task outputs accumulate over multiple executions / interventions), we cannot define task completion in terms of negatives.

The solution is to define task *completion* in terms of positives. This is also clearer and easier to implement.


### Implementation detail: Exposing the completion condition

A bonus of the new definition of task completion is that we can define the default completion condition for a task in a single flat expression e.g:

```
( succeeded and x) or expired
```

(As opposed to the previous branched code logic)

This condition can then be exposed to the user clarifying how the optional outputs they define in the graph impact the completion of the task.

E.G:

```
a?
a:failed?
```

```console
$ cylc config -i '[runtime][a]completion'
completion = succeeded or failed
```


### Behaviour change

There has been one functional change in this amendment. Consider:

```
a?
a:failed?
a:x
```

Following the previous logic the task `a` could have been completed in one of two ways:

1. `succeeded` and `x`
2. `failed` and `x`

So the completion condition, effectively reduced to:

```
(succeeded and x) or (failed and x)
```

This isn't especially helpful as we probably wouldn't have expected `x` to be generated in the failure scenario.

I'm not sure whether this is a bug in the condition or purposeful. This amendment changes:

> All required outputs must be completed if the task **runs**. The task must succeed unless stated otherwise.

To:

> All required outputs must be completed if the task **succeeds**. The task must succeed unless stated otherwise.

Changing the default completion expression for the above example to:

```
(succeeded and x) or failed
```

Which is a tad more practical.