### PR TITLE
amendment to amendent of Proposal amendment 

### DIFF
--- a/docs/proposal-optional-output-extension.md
+++ b/docs/proposal-optional-output-extension.md
@@ -41,16 +41,33 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
    executed and that might not happen if expiry or submission are optional (or if the pre-requisites
    for `a` are not met).
 
-3. A task is incomplete if the completion condition is not satisfied and:
+3. A task is complete if the completion condition is satisfied.
 
-   * It finished executing
+   The completion condition can be defined by the user, otherwise the
+   expression is automatically generated according to the rules:
 
-   * OR Job submission failed and the `:submit` output was not optional
+   1. All required outputs (referenced in the graph) must be satisfied.
+   2. If success is optional, then the task is complete if it fails.
+   3. If submission is optional, then the task is complete if it submit-fails.
+   4. If expiry is optional, then the task is complete if it expires.
 
-   * OR The task expired and the `:expire` output was not optional
-     * This is a new condition to handle expiry
+   I.E:
+
+   ```python
+   is_complete = (
+     all(output for output in outputs if not is_optional(output))
+     or (failed if is_optional(succeeded))
+     or (submit_failed if is_optional(submitted))
+     or (expired if is_optional(expired))
+   )
+   ```
+
+   Note, a task is *in*complete, if the completion condition is not satisfied
+   but the task has a final task status (note status not output). This is the
+   same as presently implemented (8.2.x)
 
 4. `:expire` cannot be required.
+
    Similarly `:submit-fail` cannot be required.
    
    * We currently allow `:submit-fail` to be required but this doesn't really make sense.
@@ -69,6 +86,8 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
    # OK
    completion = succeeded or failed
    completion = succeeded and (x or y or z)
+   completion = (succeeded and x) or (failed and y)
+   completion = (succeeded and (x or y or z)) or failed or expired
 
    # ERROR
    completion = not failed
@@ -78,8 +97,8 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
 
    Expression to be validated (i.e. parsed) at validate time.
 
-   If the completion expression is defined, any outputs which are optional in the expression
-   should be marked as optional in the graph if used in the graph:
+   If the completion expression is user-defined, then it must be logically
+   consistent with the graph.
 
    ```
    completion(a) = succeeded and (x or y or z)
@@ -114,40 +133,36 @@ There are currently three problems with expiry (as of cylc-flow 8.1.4):
    }
    ```
 
-   Note: the completion condition only covers outputs generated when a task is executed - it cannot
-   include `:expired`, `:submit` or `:submit-fail`. It also cannot include `started` (this has to
-   happen if a task executes) or `finished` (this isn't an output).
+   The completion expression cannot include `finished` (this isn't an output).
 
-   The default condition is complete all required outputs.
+6. Expiry is only optional if it is explicitly referenced in the graph (e.g.
+   `a:expired? => x`) or permitted in the completion expression
+   (e.g. `succeeded or expired`).
 
-6. Expiry is only optional if it is explicitly referenced in the graph e.g. `a:expired? => x`.
-
-   If a task is configured to clock-expire it must be made optional via the graph - otherwise this
-   will cause a validation failure. This is designed to reduce the risk of unintended early shutdown.
-
-   For this example:
+   E.G. in these examples:
 
    ```
-   clock-expire = a
-   a => b
-   a:expired?  # This does nothing but is sufficient to pass validation
-   b:submit-fail? => c
+   a => z
+
+   b => z
+   b:expired?
+
+   c
+   # completion = succeeded or expired
    ```
 
-   Task "a" is completed in one of 2 ways:
+   If the `expired` output is set on both tasks `a` and `b`:
 
-   * It expires
-   * It executes and succeeds
+   * `a` will be incomplete.
+   * `b` will be complete (permitted in graph).
+   * `c` will be complete (permitted in completion expression).
 
-   If task "a" succeeds then task "b" must complete which can happen in one of 2 ways:
-
-   * It fails to submit
-   * It executes and succeeds
-
-   So, the expression `a => b` in the graph can be interpreted as:
-   * If "a" executes it must succeed
-   * If "a" succeeds then "b" must complete
-   * If "b" executes it must succeed
+   If a task is configured to clock-expire, but expiry is not handled in the
+   graph or permitted in the completion expression, a warning should be raised
+   informing the user that the workflow may stall. The warning should
+   recommend that they either handle the expired output in the graph if no
+   completion expression is defined, or permit it in the completion expression
+   if one is defined.
 
 7. If neither `:succeed` nor `:fail` are specified for a task in the graph then `:succeed` should
    be required.
@@ -253,7 +268,7 @@ a => x
 a:expired?
 ```
 
-`a:expired?` has to be included in the graph to avoid validation failure.
+`a:expired?` has to be included in the graph to avoid stall.
 This makes it clear that the halt is intentional.
 
 ### Output Groups


### PR DESCRIPTION
My small tweak of #189 - terminology only, but it's critical terminology for how we document this functionality.  

My (only!) problem with #189 is that it changes the meaning of terms in such a way that `incomplete task` no longer means the same thing as `a task that is not complete`.  Given the universally agreed meaning of those very commonly used words, we can't do that.

We have to (or at least it makes undeniable sense to) describe outputs as "complete" or "incomplete", but we do not have to call tasks "complete" or "incomplete". The only essential concepts are:
- is the task "finished" or not (i.e., does it have a final task status)
- are its outputs complete or not

So, my proposed amendment to the proposed amendment to the amended proposal is essentially this:
- task outputs can be described as complete or incomplete
- tasks can be described as finished or not finished (final task status)
- task pool removal depends on tasks being finished with complete outputs

As non-essential bonus I propose we shorten (when appropriate) "finished with complete outputs" to "done" (the task has done its job in the workflow and the scheduler can forget it)

This branch is a clone of 189, with another commit (mine) on top. So the full diff includes all the changes of @oliver-sanders plus mine. Look at the final commit alone to see my on-top changes.


