### PR TITLE
bump rose version

### DIFF
--- a/docs/status/branches.json
+++ b/docs/status/branches.json
@@ -30,7 +30,7 @@
             "cylc/cylc-rose": "1.7.x",
             "cylc/cylc-uiserver": "1.8.x",
             "cylc/cylc-ui": "2.x",
-            "metomi/rose": "2.6.x"
+            "metomi/rose": "2.7.x"
         }
     },
     "branch_actions": {


### PR DESCRIPTION
Adapt to the new Rose release.

I have chosen not to add a 2.6.x branch for Rose although this is still "live" (i.e, compatible with latest Cylc) as we are no longer developing this.